### PR TITLE
Implement some missing traits for Map and Set.

### DIFF
--- a/fixed-map-derive/src/lib.rs
+++ b/fixed-map-derive/src/lib.rs
@@ -180,7 +180,7 @@ fn impl_storage_enum(ast: &DeriveInput, en: &DataEnum) -> TokenStream {
 
     quote! {
         const #const_wrapper: () = {
-            #[derive(Clone)]
+            #[derive(Clone, PartialEq, Eq)]
             #vis struct Storage<V: 'static> {
                 #(#fields,)*
             }

--- a/src/map.rs
+++ b/src/map.rs
@@ -584,6 +584,23 @@ where
     }
 }
 
+impl<K, V> PartialEq for Map<K, V>
+where
+    K: Key<K, V>,
+    K::Storage: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.storage == other.storage
+    }
+}
+
+impl<K, V> Eq for Map<K, V>
+where
+    K: Key<K, V>,
+    K::Storage: Eq,
+{
+}
+
 /// An iterator over the entries of a `Map`.
 ///
 /// This `struct` is created by the [`iter`] method on [`Map`]. See its

--- a/src/map.rs
+++ b/src/map.rs
@@ -561,6 +561,15 @@ where
     }
 }
 
+impl<K, V> Default for Map<K, V>
+where
+    K: Key<K, V>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// An iterator over the entries of a `Map`.
 ///
 /// This `struct` is created by the [`iter`] method on [`Map`]. See its

--- a/src/map.rs
+++ b/src/map.rs
@@ -570,6 +570,20 @@ where
     }
 }
 
+impl<K, V> std::fmt::Debug for Map<K, V>
+where
+    K: Key<K, V> + std::fmt::Debug,
+    V: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut debug_map = f.debug_map();
+        self.iter_fn(|(k, v)| {
+            debug_map.entry(&k, v);
+        });
+        debug_map.finish()
+    }
+}
+
 /// An iterator over the entries of a `Map`.
 ///
 /// This `struct` is created by the [`iter`] method on [`Map`]. See its

--- a/src/set.rs
+++ b/src/set.rs
@@ -370,6 +370,15 @@ where
     }
 }
 
+impl<K> Default for Set<K>
+where
+    K: Key<K, ()>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// An iterator over the items of a `Set`.
 ///
 /// This `struct` is created by the [`iter`] method on [`Set`].

--- a/src/set.rs
+++ b/src/set.rs
@@ -379,6 +379,19 @@ where
     }
 }
 
+impl<K> std::fmt::Debug for Set<K>
+where
+    K: Key<K, ()> + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut debug_set = f.debug_set();
+        self.iter_fn(|k| {
+            debug_set.entry(&k);
+        });
+        debug_set.finish()
+    }
+}
+
 /// An iterator over the items of a `Set`.
 ///
 /// This `struct` is created by the [`iter`] method on [`Set`].

--- a/src/set.rs
+++ b/src/set.rs
@@ -392,6 +392,23 @@ where
     }
 }
 
+impl<K> PartialEq for Set<K>
+where
+    K: Key<K, ()>,
+    K::Storage: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.storage == other.storage
+    }
+}
+
+impl<K> Eq for Set<K>
+where
+    K: Key<K, ()>,
+    K::Storage: Eq,
+{
+}
+
 /// An iterator over the items of a `Set`.
 ///
 /// This `struct` is created by the [`iter`] method on [`Set`].

--- a/src/storage/boolean.rs
+++ b/src/storage/boolean.rs
@@ -28,6 +28,17 @@ impl<V: 'static> Default for BooleanStorage<V> {
     }
 }
 
+impl<V: 'static> PartialEq for BooleanStorage<V>
+where
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.t == other.t && self.f == other.f
+    }
+}
+
+impl<V: 'static> Eq for BooleanStorage<V> where V: Eq {}
+
 impl<V> Storage<bool, V> for BooleanStorage<V> {
     #[inline]
     fn insert(&mut self, key: bool, value: V) -> Option<V> {

--- a/src/storage/map.rs
+++ b/src/storage/map.rs
@@ -29,6 +29,23 @@ where
     }
 }
 
+impl<K: 'static, V: 'static> PartialEq for MapStorage<K, V>
+where
+    K: Eq + hash::Hash,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<K: 'static, V: 'static> Eq for MapStorage<K, V>
+where
+    K: Eq + hash::Hash,
+    V: Eq,
+{
+}
+
 impl<K, V> Storage<K, V> for MapStorage<K, V>
 where
     K: Copy + Eq + hash::Hash,

--- a/src/storage/option.rs
+++ b/src/storage/option.rs
@@ -36,6 +36,25 @@ where
     }
 }
 
+impl<K: 'static, V: 'static> PartialEq for OptionStorage<K, V>
+where
+    K: Key<K, V>,
+    K::Storage: PartialEq,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.none == other.none && self.some == other.some
+    }
+}
+
+impl<K: 'static, V: 'static> Eq for OptionStorage<K, V>
+where
+    K: Key<K, V>,
+    K::Storage: Eq,
+    V: Eq,
+{
+}
+
 impl<K, V> Storage<Option<K>, V> for OptionStorage<K, V>
 where
     K: Key<K, V>,

--- a/src/storage/singleton.rs
+++ b/src/storage/singleton.rs
@@ -29,6 +29,17 @@ impl<K: 'static, V: 'static> Default for SingletonStorage<K, V> {
     }
 }
 
+impl<K: 'static, V: 'static> PartialEq for SingletonStorage<K, V>
+where
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<K: 'static, V: 'static> Eq for SingletonStorage<K, V> where V: Eq {}
+
 impl<K: 'static, V: 'static> Storage<K, V> for SingletonStorage<K, V>
 where
     K: Default,


### PR DESCRIPTION
This PR implements Default, Debug, PartialEq, and Eq for Map and Set. Default and Debug seem harmless to implement. PartialEq and Eq probably need some consideration. The way I implemented these is by having equality on a map if there is equality on the storage. This does not require the keys themselves to have equality, and only requires the values to have equality if the implementation of equality for the storage requires it (which the premade and derived ones do). I wonder whether there should be an explicit requirement for the values to have equality on the map impl for equality.