### PR TITLE
Forbid unsafe, edition 2021, MSRV 1.65, more lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: --cfg ci
     steps:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: beta
         override: true
+        profile: minimal
+    - run: cargo build --all-features
     - run: cargo build --no-default-features
     - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "fixed-map"
 version = "0.8.0-alpha.2"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.65"
 license = "MIT/Apache-2.0"
 categories = ["data-structures"]
 

--- a/README.md
+++ b/README.md
@@ -148,14 +148,6 @@ if let Some(item) = map.get(Dir::North) {
 }
 ```
 
-### Unsafe use
-
-This crate uses unsafe for its iterators. This is needed because there is no
-proper way to associate generic lifetimes to associated types.
-
-Instead, we associate the lifetime to the container (`Map` or `Set`) which
-wraps a set of unsafe derefs over raw pointers.
-
 ### Benchmarks
 
 In the following benchmarks, fixed-map is compared to:

--- a/fixed-map-derive/src/lib.rs
+++ b/fixed-map-derive/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "256"]
+#![deny(unsafe_code)]
 
 extern crate proc_macro;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,11 @@
 //!
 //! The following features are available:
 //!
+//! * `std` - Disabling this feature enables causes this crate to be no-std.
+//!   This means that dynamic types cannot be used in keys, like ones enabled by
+//!   the `map` feature (default).
 //! * `map` - Causes [Storage] to be implemented by dynamic types such as
-//!   `&'static str` or `u32`. These are backed by a `hashbrown` HashMap
-//!   (default).
+//!   `&'static str` or `u32`. These are backed by a `hashbrown` (default).
 //! * `serde` - Causes [Map] and [Set] to implement [Serialize] and
 //!   [Deserialize] if it's implemented by the key and value.
 //!
@@ -243,6 +245,41 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
+#![deny(unsafe_code)]
+// Pedantic CI settings that might not be future proof or solely involves
+// clippy.
+#![cfg_attr(ci, deny(clippy::all))]
+#![cfg_attr(ci, deny(warnings))]
+#![cfg_attr(ci, warn(clippy::pedantic))]
+// style choice
+#![allow(clippy::module_name_repetitions)]
+// false positive
+#![allow(clippy::type_repetition_in_bounds)]
+// false positive
+#![allow(clippy::expl_impl_clone_on_copy)]
+// Enable more useful rustc lints
+#![cfg_attr(ci, deny(absolute_paths_not_starting_with_crate))]
+#![cfg_attr(ci, deny(elided_lifetimes_in_paths))]
+#![cfg_attr(ci, deny(explicit_outlives_requirements))]
+#![cfg_attr(ci, deny(keyword_idents))]
+#![cfg_attr(ci, deny(macro_use_extern_crate))]
+#![cfg_attr(ci, deny(meta_variable_misuse))]
+#![cfg_attr(ci, deny(missing_copy_implementations))]
+#![cfg_attr(ci, deny(missing_docs))]
+#![cfg_attr(ci, deny(non_ascii_idents))]
+#![cfg_attr(ci, deny(noop_method_call))]
+#![cfg_attr(ci, deny(pointer_structural_match))]
+#![cfg_attr(ci, deny(single_use_lifetimes))]
+#![cfg_attr(ci, deny(trivial_casts))]
+#![cfg_attr(ci, deny(trivial_numeric_casts))]
+#![cfg_attr(ci, deny(unreachable_pub))]
+#![cfg_attr(ci, deny(unused_extern_crates))]
+#![cfg_attr(ci, deny(unused_import_braces))]
+#![cfg_attr(ci, deny(unused_lifetimes))]
+#![cfg_attr(ci, deny(unused_macro_rules))]
+#![cfg_attr(ci, deny(unused_qualifications))]
+#![cfg_attr(ci, deny(unused_tuple_struct_fields))]
+#![cfg_attr(ci, deny(variant_size_differences))]
 
 pub mod key;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,6 @@
 //! Contains the fixed `Map` implementation.
 
 use core::fmt;
-use core::iter;
 
 use crate::{key::Key, storage::Storage};
 
@@ -144,6 +143,7 @@ where
     /// let mut map: Map<Key, i32> = Map::new();
     /// ```
     #[inline]
+    #[must_use]
     pub fn new() -> Map<K, V> {
         Map {
             storage: K::Storage::default(),
@@ -422,7 +422,7 @@ where
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        self.storage.clear()
+        self.storage.clear();
     }
 
     /// Returns true if the map contains no elements.
@@ -507,11 +507,13 @@ where
     K: Key<K, V> + fmt::Debug,
     V: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_map = f.debug_map();
+
         for (k, v) in self.iter() {
             debug_map.entry(&k, v);
         }
+
         debug_map.finish()
     }
 }
@@ -698,7 +700,7 @@ where
 /// [`keys`]: struct.Map.html#method.keys
 /// [`Map`]: struct.Map.html
 #[derive(Clone)]
-pub struct Keys<'a, K, V: 'a>
+pub struct Keys<'a, K, V>
 where
     K: Key<K, V>,
 {
@@ -752,7 +754,7 @@ where
 ///
 /// [`values_mut`]: struct.Map.html#method.values_mut
 /// [`Map`]: struct.Map.html
-pub struct ValuesMut<'a, K, V: 'a>
+pub struct ValuesMut<'a, K, V>
 where
     K: Key<K, V>,
 {
@@ -771,7 +773,7 @@ where
     }
 }
 
-impl<K, V> iter::FromIterator<(K, V)> for Map<K, V>
+impl<K, V> FromIterator<(K, V)> for Map<K, V>
 where
     K: Key<K, V>,
 {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,7 +1,6 @@
 //! Contains the fixed `Set` implementation.
 
 use core::fmt;
-use core::iter;
 
 use crate::key::Key;
 use crate::storage::Storage;
@@ -125,6 +124,7 @@ where
     /// let set: Set<Key> = Set::new();
     /// ```
     #[inline]
+    #[must_use]
     pub fn new() -> Set<K> {
         Set {
             storage: K::Storage::default(),
@@ -153,7 +153,7 @@ where
     /// assert_eq!(map.iter().collect::<Vec<_>>(), vec![Key::One, Key::Two]);
     /// ```
     #[inline]
-    pub fn iter(&self) -> Iter<K> {
+    pub fn iter(&self) -> Iter<'_, K> {
         Iter {
             iter: self.storage.iter(),
         }
@@ -257,7 +257,7 @@ where
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        self.storage.clear()
+        self.storage.clear();
     }
 
     /// Returns true if the set contains no elements.
@@ -320,6 +320,13 @@ where
     }
 }
 
+impl<K> Copy for Set<K>
+where
+    K: Key<K, ()>,
+    K::Storage: Copy,
+{
+}
+
 impl<K> Default for Set<K>
 where
     K: Key<K, ()>,
@@ -334,7 +341,7 @@ impl<K> fmt::Debug for Set<K>
 where
     K: Key<K, ()> + fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_set = f.debug_set();
         for k in self.iter() {
             debug_set.entry(&k);
@@ -375,7 +382,7 @@ where
     iter: <<K as Key<K, ()>>::Storage as Storage<K, ()>>::Iter<'a>,
 }
 
-impl<'a, K> Iterator for Iter<'a, K>
+impl<K> Iterator for Iter<'_, K>
 where
     K: Key<K, ()>,
 {
@@ -459,7 +466,7 @@ where
     }
 }
 
-impl<K> iter::FromIterator<K> for Set<K>
+impl<K> FromIterator<K> for Set<K>
 where
     K: Key<K, ()>,
 {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,21 +20,18 @@ pub use self::singleton::SingletonStorage;
 /// - `V` is the value being stored.
 pub trait Storage<K, V>: Default {
     /// Immutable iterator over storage.
-    /// Uses raw pointers (unsafe) since we don't have GATs.
     type Iter<'this>: Clone + Iterator<Item = (K, &'this V)>
     where
         Self: 'this,
         V: 'this;
 
     /// Immutable iterator over storage.
-    /// Uses raw pointers (unsafe) since we don't have GATs.
     type Values<'this>: Clone + Iterator<Item = &'this V>
     where
         Self: 'this,
         V: 'this;
 
     /// Mutable iterator over storage.
-    /// Uses raw pointers (unsafe) since we don't have GATs.
     type IterMut<'this>: Iterator<Item = (K, &'this mut V)>
     where
         Self: 'this,

--- a/src/storage/boolean.rs
+++ b/src/storage/boolean.rs
@@ -3,45 +3,21 @@ use core::mem;
 use crate::storage::Storage;
 
 /// Storage for `bool`s.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct BooleanStorage<V> {
     t: Option<V>,
     f: Option<V>,
-}
-
-impl<V> Clone for BooleanStorage<V>
-where
-    V: Clone,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        BooleanStorage {
-            t: self.t.clone(),
-            f: self.f.clone(),
-        }
-    }
 }
 
 impl<V> Default for BooleanStorage<V> {
     #[inline]
     fn default() -> Self {
         Self {
-            t: Default::default(),
-            f: Default::default(),
+            t: Option::default(),
+            f: Option::default(),
         }
     }
 }
-
-impl<V> PartialEq for BooleanStorage<V>
-where
-    V: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.t == other.t && self.f == other.f
-    }
-}
-
-impl<V> Eq for BooleanStorage<V> where V: Eq {}
 
 pub struct Iter<'a, V> {
     t: Option<&'a V>,
@@ -67,11 +43,7 @@ impl<'a, V> Iterator for Iter<'a, V> {
             return Some((true, t));
         }
 
-        if let Some(f) = self.f.take() {
-            return Some((false, f));
-        }
-
-        None
+        Some((false, self.f.take()?))
     }
 }
 
@@ -151,33 +123,37 @@ impl<V> Storage<bool, V> for BooleanStorage<V> {
 
     #[inline]
     fn insert(&mut self, key: bool, value: V) -> Option<V> {
-        match key {
-            true => mem::replace(&mut self.t, Some(value)),
-            false => mem::replace(&mut self.f, Some(value)),
+        if key {
+            mem::replace(&mut self.t, Some(value))
+        } else {
+            mem::replace(&mut self.f, Some(value))
         }
     }
 
     #[inline]
     fn get(&self, key: bool) -> Option<&V> {
-        match key {
-            true => self.t.as_ref(),
-            false => self.f.as_ref(),
+        if key {
+            self.t.as_ref()
+        } else {
+            self.f.as_ref()
         }
     }
 
     #[inline]
     fn get_mut(&mut self, key: bool) -> Option<&mut V> {
-        match key {
-            true => self.t.as_mut(),
-            false => self.f.as_mut(),
+        if key {
+            self.t.as_mut()
+        } else {
+            self.f.as_mut()
         }
     }
 
     #[inline]
     fn remove(&mut self, key: bool) -> Option<V> {
-        match key {
-            true => mem::replace(&mut self.t, None),
-            false => mem::replace(&mut self.f, None),
+        if key {
+            mem::replace(&mut self.t, None)
+        } else {
+            mem::replace(&mut self.f, None)
         }
     }
 

--- a/src/storage/map.rs
+++ b/src/storage/map.rs
@@ -1,6 +1,6 @@
-use crate::storage::Storage;
-
 use core::hash;
+
+use crate::storage::Storage;
 
 /// Storage for static types that must be stored in a map.
 #[repr(transparent)]
@@ -28,7 +28,7 @@ where
     #[inline]
     fn default() -> Self {
         Self {
-            inner: Default::default(),
+            inner: ::hashbrown::HashMap::default(),
         }
     }
 }
@@ -51,10 +51,7 @@ where
 {
 }
 
-pub struct Iter<'a, K, V>
-where
-    K: 'a,
-{
+pub struct Iter<'a, K, V> {
     iter: hashbrown::hash_map::Iter<'a, K, V>,
 }
 
@@ -70,7 +67,10 @@ where
     }
 }
 
-impl<'a, K: Copy, V> Iterator for Iter<'a, K, V> {
+impl<'a, K, V> Iterator for Iter<'a, K, V>
+where
+    K: Copy,
+{
     type Item = (K, &'a V);
 
     #[inline]
@@ -83,7 +83,10 @@ pub struct IterMut<'a, K, V> {
     iter: hashbrown::hash_map::IterMut<'a, K, V>,
 }
 
-impl<'a, K: Copy, V> Iterator for IterMut<'a, K, V> {
+impl<'a, K, V> Iterator for IterMut<'a, K, V>
+where
+    K: Copy,
+{
     type Item = (K, &'a mut V);
 
     #[inline]

--- a/src/storage/option.rs
+++ b/src/storage/option.rs
@@ -17,9 +17,8 @@ where
     K::Storage: Clone,
     V: Clone,
 {
-    #[inline]
     fn clone(&self) -> Self {
-        OptionStorage {
+        Self {
             some: self.some.clone(),
             none: self.none.clone(),
         }
@@ -41,8 +40,8 @@ where
     #[inline]
     fn default() -> Self {
         Self {
-            some: Default::default(),
-            none: Default::default(),
+            some: K::Storage::default(),
+            none: Option::default(),
         }
     }
 }
@@ -69,7 +68,6 @@ where
 pub struct Iter<'a, K, V>
 where
     K: 'a + Key<K, V>,
-    V: 'a,
 {
     some: <K::Storage as Storage<K, V>>::Iter<'a>,
     none: Option<&'a V>,
@@ -111,7 +109,6 @@ where
 pub struct Values<'a, K, V>
 where
     K: 'a + Key<K, V>,
-    V: 'a,
 {
     some: <K::Storage as Storage<K, V>>::Values<'a>,
     none: Option<&'a V>,
@@ -145,7 +142,6 @@ where
 pub struct IterMut<'a, K, V>
 where
     K: 'a + Key<K, V>,
-    V: 'a,
 {
     some: <K::Storage as Storage<K, V>>::IterMut<'a>,
     none: Option<&'a mut V>,

--- a/src/storage/singleton.rs
+++ b/src/storage/singleton.rs
@@ -4,29 +4,16 @@ use crate::storage::Storage;
 
 /// Storage types that can only inhabit a single value (like `()`).
 #[repr(transparent)]
+#[derive(Clone, Copy)]
 pub struct SingletonStorage<V> {
     inner: Option<V>,
 }
-
-impl<V> Clone for SingletonStorage<V>
-where
-    V: Clone,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        SingletonStorage {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<V> Copy for SingletonStorage<V> where V: Copy {}
 
 impl<V> Default for SingletonStorage<V> {
     #[inline]
     fn default() -> Self {
         Self {
-            inner: Default::default(),
+            inner: Option::default(),
         }
     }
 }
@@ -47,7 +34,7 @@ pub struct Iter<'a, K, V> {
     value: Option<(K, &'a V)>,
 }
 
-impl<'a, K, V> Clone for Iter<'a, K, V>
+impl<K, V> Clone for Iter<'_, K, V>
 where
     K: Copy,
 {


### PR DESCRIPTION
- Forbid unsafe code and remove legacy unsafe-related docs
- Switch to edition 2021
- Set `rust-version` in Cargo.toml to 1.65
- Enable pedantic clippy lints
- Enable more rustc lints (see daf57cd0185014e6cf5bf154cb731b6345ff35f1 for details on the exceptions)