### PR TITLE
Fixes, macro improvements, and iteration performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,5 @@ jobs:
       with:
         toolchain: beta
         override: true
+    - run: cargo build --no-default-features
     - run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,14 @@ readme = "README.md"
 all-features = true
 
 [features]
-default = ["map"]
-map = ["hashbrown"]
+default = ["map", "std"]
+std = ["serde?/std"]
+map = ["hashbrown", "std"]
 
 [dependencies]
 fixed-map-derive = { version = "0.8.0-alpha.2", path = "fixed-map-derive" }
 hashbrown = { version = "0.12.3", optional = true }
-serde = { version = "1.0.145", optional = true }
+serde = { version = "1.0.145", optional = true, default_features = false }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,14 @@
+use fixed_map::{Key, Map};
+
+#[derive(Debug, Clone, Copy, Key)]
+enum Key {
+    First,
+    Second,
+}
+
+fn main() {
+    let mut map = Map::new();
+    map.insert(Key::First, 42);
+    assert_eq!(map.get(Key::First), Some(&42));
+    assert_eq!(map.get(Key::Second), None);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,9 @@
 //! [Map]: https://docs.rs/fixed-map/*/fixed_map/map/struct.Map.html
 //! [Serialize]: https://docs.rs/serde/1/serde/trait.Serialize.html
 //! [Set]: https://docs.rs/fixed-map/*/fixed_map/map/struct.Set.html
+//! [Storage]: https://docs.rs/fixed-map/*/fixed_map/storage/trait.Storage.html
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 
 pub mod key;

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,8 @@
 //! Contains the fixed `Set` implementation.
+
+use core::fmt;
+use core::iter;
+
 use crate::key::Key;
 use crate::storage::Storage;
 
@@ -326,11 +330,11 @@ where
     }
 }
 
-impl<K> std::fmt::Debug for Set<K>
+impl<K> fmt::Debug for Set<K>
 where
-    K: Key<K, ()> + std::fmt::Debug,
+    K: Key<K, ()> + fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut debug_set = f.debug_set();
         for k in self.iter() {
             debug_set.entry(&k);
@@ -455,12 +459,15 @@ where
     }
 }
 
-impl<K> std::iter::FromIterator<K> for Set<K>
+impl<K> iter::FromIterator<K> for Set<K>
 where
     K: Key<K, ()>,
 {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = K>,
+    {
         let mut set = Self::new();
         for k in iter {
             set.insert(k);
@@ -499,9 +506,9 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        return deserializer.deserialize_seq(SeqVisitor(std::marker::PhantomData));
+        return deserializer.deserialize_seq(SeqVisitor(core::marker::PhantomData));
 
-        struct SeqVisitor<K>(std::marker::PhantomData<K>);
+        struct SeqVisitor<K>(core::marker::PhantomData<K>);
 
         impl<'de, K> serde::de::Visitor<'de> for SeqVisitor<K>
         where
@@ -509,7 +516,7 @@ where
         {
             type Value = Set<K>;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a sequence")
             }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -26,6 +26,13 @@ pub trait Storage<K, V>: Default {
         Self: 'this,
         V: 'this;
 
+    /// Immutable iterator over storage.
+    /// Uses raw pointers (unsafe) since we don't have GATs.
+    type Values<'this>: Clone + Iterator<Item = &'this V>
+    where
+        Self: 'this,
+        V: 'this;
+
     /// Mutable iterator over storage.
     /// Uses raw pointers (unsafe) since we don't have GATs.
     type IterMut<'this>: Iterator<Item = (K, &'this mut V)>
@@ -53,6 +60,9 @@ pub trait Storage<K, V>: Default {
 
     /// This is the storage abstraction for [`Map::iter`](struct.Map.html#method.iter).
     fn iter(&self) -> Self::Iter<'_>;
+
+    /// This is the storage abstraction for [`Map::values`](struct.Map.html#method.values).
+    fn values(&self) -> Self::Values<'_>;
 
     /// This is the storage abstraction for [`Map::iter_mut`](struct.Map.html#method.iter_mut).
     fn iter_mut(&mut self) -> Self::IterMut<'_>;

--- a/src/storage/boolean.rs
+++ b/src/storage/boolean.rs
@@ -1,5 +1,6 @@
+use core::mem;
+
 use crate::storage::Storage;
-use std::mem;
 
 /// Storage for `bool`s.
 pub struct BooleanStorage<V> {
@@ -74,6 +75,30 @@ impl<'a, V> Iterator for Iter<'a, V> {
     }
 }
 
+pub struct Values<'a, V> {
+    t: Option<&'a V>,
+    f: Option<&'a V>,
+}
+
+impl<'a, V> Clone for Values<'a, V> {
+    #[inline]
+    fn clone(&self) -> Values<'a, V> {
+        Values {
+            t: self.t,
+            f: self.f,
+        }
+    }
+}
+
+impl<'a, V> Iterator for Values<'a, V> {
+    type Item = &'a V;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.t.take().or(self.f.take())
+    }
+}
+
 pub struct IterMut<'a, V> {
     t: Option<&'a mut V>,
     f: Option<&'a mut V>,
@@ -120,6 +145,7 @@ impl<V> Iterator for IntoIter<V> {
 
 impl<V> Storage<bool, V> for BooleanStorage<V> {
     type Iter<'this> = Iter<'this, V> where Self: 'this;
+    type Values<'this> = Values<'this, V> where Self: 'this;
     type IterMut<'this> = IterMut<'this, V> where Self: 'this;
     type IntoIter = IntoIter<V>;
 
@@ -164,6 +190,14 @@ impl<V> Storage<bool, V> for BooleanStorage<V> {
     #[inline]
     fn iter(&self) -> Self::Iter<'_> {
         Iter {
+            t: self.t.as_ref(),
+            f: self.f.as_ref(),
+        }
+    }
+
+    #[inline]
+    fn values(&self) -> Self::Values<'_> {
+        Values {
             t: self.t.as_ref(),
             f: self.f.as_ref(),
         }

--- a/src/storage/map.rs
+++ b/src/storage/map.rs
@@ -1,9 +1,11 @@
 use crate::storage::Storage;
-use std::hash;
+
+use core::hash;
 
 /// Storage for static types that must be stored in a map.
+#[repr(transparent)]
 pub struct MapStorage<K, V> {
-    inner: hashbrown::HashMap<K, V>,
+    inner: ::hashbrown::HashMap<K, V>,
 }
 
 impl<K, V> Clone for MapStorage<K, V>
@@ -95,6 +97,7 @@ where
     K: Copy + Eq + hash::Hash,
 {
     type Iter<'this> = Iter<'this, K, V> where Self: 'this, V: 'this;
+    type Values<'this> = ::hashbrown::hash_map::Values<'this, K, V> where Self: 'this;
     type IterMut<'this> = IterMut<'this, K, V> where Self: 'this, V: 'this;
     type IntoIter = hashbrown::hash_map::IntoIter<K, V>;
 
@@ -128,6 +131,11 @@ where
         Iter {
             iter: self.inner.iter(),
         }
+    }
+
+    #[inline]
+    fn values(&self) -> Self::Values<'_> {
+        self.inner.values()
     }
 
     #[inline]

--- a/src/storage/singleton.rs
+++ b/src/storage/singleton.rs
@@ -1,7 +1,9 @@
+use core::mem;
+
 use crate::storage::Storage;
-use std::mem;
 
 /// Storage types that can only inhabit a single value (like `()`).
+#[repr(transparent)]
 pub struct SingletonStorage<V> {
     inner: Option<V>,
 }
@@ -17,6 +19,8 @@ where
         }
     }
 }
+
+impl<V> Copy for SingletonStorage<V> where V: Copy {}
 
 impl<V> Default for SingletonStorage<V> {
     #[inline]
@@ -93,6 +97,7 @@ where
     K: Copy + Default,
 {
     type Iter<'this> = Iter<'this, K, V> where Self: 'this, V: 'this;
+    type Values<'this> = ::core::option::Iter<'this, V> where Self: 'this, V: 'this;
     type IterMut<'this> = IterMut<'this, K, V> where Self: 'this, V: 'this;
     type IntoIter = IntoIter<K, V>;
 
@@ -126,6 +131,11 @@ where
         Iter {
             value: self.inner.as_ref().map(|v| (K::default(), v)),
         }
+    }
+
+    #[inline]
+    fn values(&self) -> Self::Values<'_> {
+        self.inner.iter()
     }
 
     #[inline]

--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(no_std)]
+
 use fixed_map::Key;
 
 #[derive(Debug, Clone, Copy, Key)]


### PR DESCRIPTION
Adds no-std support (by disabling the `std` feature) and a bunch of `#[inline]` annotations.

This (tries to) ensure that everything that is being referenced in a proc-macro uses its fully qualified name.

Finally this adds a simpler proc macro expansion which improves iteration performance for unit enums.