### PR TITLE
Style nits and rework the entry traits

### DIFF
--- a/fixed-map-derive/src/context.rs
+++ b/fixed-map-derive/src/context.rs
@@ -58,9 +58,9 @@ impl Toks {
             occupied_entry_trait: quote!(#krate::storage::entry::OccupiedEntry),
             vacant_entry_trait: quote!(#krate::storage::entry::VacantEntry),
             entry_enum: quote!(#krate::storage::entry::Entry),
-            option_bucket_option: quote!(#krate::storage::entry::option_bucket::OptionBucket),
-            option_bucket_some: quote!(#krate::storage::entry::option_bucket::SomeBucket),
-            option_bucket_none: quote!(#krate::storage::entry::option_bucket::NoneBucket),
+            option_bucket_option: quote!(#krate::option_bucket::OptionBucket),
+            option_bucket_some: quote!(#krate::option_bucket::SomeBucket),
+            option_bucket_none: quote!(#krate::option_bucket::NoneBucket),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,6 @@
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_copy_implementations,
-    missing_docs,
     non_ascii_idents,
     noop_method_call,
     pointer_structural_match,
@@ -341,3 +340,8 @@ pub mod set;
 pub use self::set::Set;
 
 pub mod storage;
+
+// Re-export the option bucket types for use in `derive(Key)`
+#[doc(hidden)]
+#[cfg(feature = "entry")]
+pub mod option_bucket;

--- a/src/map.rs
+++ b/src/map.rs
@@ -825,10 +825,7 @@ where
     /// assert_eq!(map.get(Key::Second), Some(&vec![2; 4]));
     /// ```
     #[cfg(feature = "entry")]
-    pub fn entry(
-        &mut self,
-        key: K,
-    ) -> Entry<impl OccupiedEntry<'_, K, V>, impl VacantEntry<'_, K, V>>
+    pub fn entry(&mut self, key: K) -> Entry<'_, K::Storage<V>, K, V>
     where
         K::Storage<V>: entry::StorageEntry<K, V>,
     {

--- a/src/option_bucket.rs
+++ b/src/option_bucket.rs
@@ -26,7 +26,7 @@
 //!
 //! Safely implement [`Option::get_or_insert`]
 //! ```
-//! use fixed_map::storage::entry::option_bucket::OptionBucket;
+//! use fixed_map::option_bucket::OptionBucket;
 //!
 //! fn get_or_insert<T>(this: &mut Option<T>, value: T) -> &mut T {
 //!     match OptionBucket::new(this) {
@@ -41,14 +41,16 @@
 //!
 //! Safely implement entry API for [`Option`]
 //! ```
-//! use fixed_map::storage::entry::option_bucket::*;
+//! use fixed_map::option_bucket::*;
 //!
 //! struct OccupiedEntry<'a, T> {
 //!     inner: SomeBucket<'a, T>
 //! }
+//!
 //! struct VacantEntry<'a, T> {
 //!     inner: NoneBucket<'a, T>,
 //! }
+//!
 //! enum Entry<'a, T> {
 //!     Vacant(VacantEntry<'a, T>),
 //!     Occupied(OccupiedEntry<'a, T>),
@@ -59,6 +61,7 @@
 //!         self.inner.insert(value)
 //!     }
 //! }
+//!
 //! impl<'a, T> OccupiedEntry<'a, T> {
 //!     fn get(&self) -> &T {
 //!         self.inner.as_ref()
@@ -89,6 +92,9 @@
 // `clippy::pedantic` exceptions
 #![allow(clippy::should_implement_trait, clippy::must_use_candidate)]
 
+#[cfg(test)]
+mod tests;
+
 /// Abstraction for an [`&mut Option`][Option] that's known to be [`Some`].
 ///
 /// # Size
@@ -99,6 +105,7 @@
 pub struct SomeBucket<'a, T> {
     outer: &'a mut Option<T>,
 }
+
 impl<'a, T> SomeBucket<'a, T> {
     /// Creates a new [`SomeBucket`], without checking that
     /// the input [`Option`] is `Some`.
@@ -136,7 +143,7 @@ impl<'a, T> SomeBucket<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// # use fixed_map::storage::entry::option_bucket::SomeBucket;
+    /// # use fixed_map::option_bucket::SomeBucket;
     ///
     /// let mut text: Option<String> = Some("Hello, world!".to_string());
     /// let some = SomeBucket::new(&mut text).unwrap();
@@ -158,7 +165,7 @@ impl<'a, T> SomeBucket<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// # use fixed_map::storage::entry::option_bucket::SomeBucket;
+    /// # use fixed_map::option_bucket::SomeBucket;
     ///
     /// let mut text: Option<String> = Some("Hello, world!".to_string());
     /// let mut some = SomeBucket::new(&mut text).unwrap();
@@ -179,7 +186,7 @@ impl<'a, T> SomeBucket<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// # use fixed_map::storage::entry::option_bucket::SomeBucket;
+    /// # use fixed_map::option_bucket::SomeBucket;
     ///
     /// let mut text: Option<String> = Some("Hello, world!".to_string());
     /// let some = SomeBucket::new(&mut text).unwrap();
@@ -189,7 +196,7 @@ impl<'a, T> SomeBucket<'a, T> {
     /// ```
     ///
     /// ```compile_fail
-    /// # use fixed_map::storage::entry::option_bucket::SomeBucket;
+    /// # use fixed_map::option_bucket::SomeBucket;
     ///
     /// let mut text: Option<String> = Some("Hello, world!".to_string());
     /// let some = SomeBucket::new(&mut text).unwrap();
@@ -210,7 +217,7 @@ impl<'a, T> SomeBucket<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// # use fixed_map::storage::entry::option_bucket::SomeBucket;
+    /// # use fixed_map::option_bucket::SomeBucket;
     ///
     /// let mut x = Some(2);
     /// let mut some = SomeBucket::new(&mut x).unwrap();
@@ -227,7 +234,7 @@ impl<'a, T> SomeBucket<'a, T> {
     /// and consuming this `SomeBucket`.
     ///
     /// ```
-    /// # use fixed_map::storage::entry::option_bucket::SomeBucket;
+    /// # use fixed_map::option_bucket::SomeBucket;
     ///
     /// let mut x = Some(vec![1, 2]);
     /// let some = SomeBucket::new(&mut x).unwrap();
@@ -251,6 +258,7 @@ impl<'a, T> SomeBucket<'a, T> {
 pub struct NoneBucket<'a, T> {
     outer: &'a mut Option<T>,
 }
+
 impl<'a, T> NoneBucket<'a, T> {
     /// Creates a new [`NoneBucket`], without checking that
     /// the input [`Option`] is `None`.
@@ -289,7 +297,7 @@ impl<'a, T> NoneBucket<'a, T> {
     /// operations handling [`drop`]ping the old value
     /// (since we know there was no old value).
     /// ```
-    /// # use fixed_map::storage::entry::option_bucket::NoneBucket;
+    /// # use fixed_map::option_bucket::NoneBucket;
     ///
     /// let mut opt = None;
     /// let mut none = NoneBucket::new(&mut opt).unwrap();
@@ -319,13 +327,14 @@ pub enum OptionBucket<'a, T> {
     /// An option known to be `None`.
     None(NoneBucket<'a, T>),
 }
+
 impl<'a, T> OptionBucket<'a, T> {
     /// Create an `OptionBucket` from an `&mut Option`.
     ///
     /// # Examples
     ///
     /// ```
-    /// use fixed_map::storage::entry::option_bucket::OptionBucket;
+    /// use fixed_map::option_bucket::OptionBucket;
     ///
     /// let mut none: Option<i32> = None;
     /// let none_bucket = OptionBucket::new(&mut none);
@@ -343,135 +352,5 @@ impl<'a, T> OptionBucket<'a, T> {
             // SAFETY: if conditional ensures that `opt` is `None`
             unsafe { OptionBucket::None(NoneBucket::new_unchecked(opt)) }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #![allow(clippy::too_many_lines, unreachable_pub)]
-    use super::*;
-
-    #[test]
-    fn test() {
-        struct OccupiedEntry<'a, T> {
-            inner: SomeBucket<'a, T>,
-        }
-        struct VacantEntry<'a, T> {
-            inner: NoneBucket<'a, T>,
-        }
-
-        enum Entry<'a, T> {
-            Vacant(VacantEntry<'a, T>),
-            Occupied(OccupiedEntry<'a, T>),
-        }
-
-        impl<'a, T> VacantEntry<'a, T> {
-            fn insert(self, value: T) -> &'a mut T {
-                self.inner.insert(value)
-            }
-        }
-
-        impl<'a, T> OccupiedEntry<'a, T> {
-            fn get(&self) -> &T {
-                self.inner.as_ref()
-            }
-
-            fn get_mut(&mut self) -> &mut T {
-                self.inner.as_mut()
-            }
-
-            fn into_mut(self) -> &'a mut T {
-                self.inner.into_mut()
-            }
-
-            fn insert(&mut self, value: T) -> T {
-                self.inner.replace(value)
-            }
-
-            fn remove(self) -> T {
-                self.inner.take()
-            }
-        }
-
-        impl<'a, T> Entry<'a, T> {
-            pub fn or_insert(self, default: T) -> &'a mut T {
-                match self {
-                    Entry::Occupied(entry) => entry.into_mut(),
-                    Entry::Vacant(entry) => entry.insert(default),
-                }
-            }
-
-            pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> &'a mut T {
-                match self {
-                    Entry::Occupied(entry) => entry.into_mut(),
-                    Entry::Vacant(entry) => entry.insert(default()),
-                }
-            }
-
-            pub fn and_modify<F: FnOnce(&mut T)>(self, f: F) -> Self {
-                match self {
-                    Entry::Occupied(mut entry) => {
-                        f(entry.get_mut());
-                        Entry::Occupied(entry)
-                    }
-                    Entry::Vacant(entry) => Entry::Vacant(entry),
-                }
-            }
-
-            pub fn or_default(self) -> &'a mut T
-            where
-                T: Default,
-            {
-                match self {
-                    Entry::Occupied(entry) => entry.into_mut(),
-                    Entry::Vacant(entry) => entry.insert(Default::default()),
-                }
-            }
-        }
-
-        trait OptionEntry {
-            type Entry<'this>
-            where
-                Self: 'this;
-            fn entry(&mut self) -> Self::Entry<'_>;
-        }
-
-        impl<T> OptionEntry for Option<T> {
-            type Entry<'this> = Entry<'this, T> where Self: 'this;
-            fn entry(&mut self) -> Self::Entry<'_> {
-                match OptionBucket::new(self) {
-                    OptionBucket::Some(inner) => Entry::Occupied(OccupiedEntry { inner }),
-                    OptionBucket::None(inner) => Entry::Vacant(VacantEntry { inner }),
-                }
-            }
-        }
-
-        let mut even: Option<i32> = None;
-
-        for n in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] {
-            if n % 2 == 0 {
-                even.entry().and_modify(|x| *x += 1).or_insert(1);
-            }
-        }
-
-        match even.entry() {
-            Entry::Occupied(mut entry) => {
-                assert_eq!(entry.get(), &5);
-                assert_eq!(entry.insert(-3), 5);
-                assert_eq!(entry.remove(), -3);
-            }
-            Entry::Vacant(_) => unreachable!(),
-        }
-        assert!(even.is_none());
-
-        let day_hours = 24;
-
-        let mut x = None;
-        x.entry().or_insert_with(|| day_hours * 60 * 60 * 1000);
-        assert_eq!(x, Some(86_400_000));
-
-        let mut y: Option<u32> = None;
-        y.entry().or_default();
-        assert_eq!(y, Some(0));
     }
 }

--- a/src/option_bucket/tests.rs
+++ b/src/option_bucket/tests.rs
@@ -1,0 +1,128 @@
+use super::{NoneBucket, OptionBucket, SomeBucket};
+
+struct OccupiedEntry<'a, T> {
+    inner: SomeBucket<'a, T>,
+}
+
+struct VacantEntry<'a, T> {
+    inner: NoneBucket<'a, T>,
+}
+
+enum Entry<'a, T> {
+    Vacant(VacantEntry<'a, T>),
+    Occupied(OccupiedEntry<'a, T>),
+}
+
+impl<'a, T> VacantEntry<'a, T> {
+    fn insert(self, value: T) -> &'a mut T {
+        self.inner.insert(value)
+    }
+}
+
+impl<'a, T> OccupiedEntry<'a, T> {
+    fn get(&self) -> &T {
+        self.inner.as_ref()
+    }
+
+    fn get_mut(&mut self) -> &mut T {
+        self.inner.as_mut()
+    }
+
+    fn into_mut(self) -> &'a mut T {
+        self.inner.into_mut()
+    }
+
+    fn insert(&mut self, value: T) -> T {
+        self.inner.replace(value)
+    }
+
+    fn remove(self) -> T {
+        self.inner.take()
+    }
+}
+
+impl<'a, T> Entry<'a, T> {
+    fn or_insert(self, default: T) -> &'a mut T {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> &'a mut T {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    fn and_modify<F: FnOnce(&mut T)>(self, f: F) -> Self {
+        match self {
+            Entry::Occupied(mut entry) => {
+                f(entry.get_mut());
+                Entry::Occupied(entry)
+            }
+            Entry::Vacant(entry) => Entry::Vacant(entry),
+        }
+    }
+
+    fn or_default(self) -> &'a mut T
+    where
+        T: Default,
+    {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Default::default()),
+        }
+    }
+}
+
+trait OptionEntry {
+    type Entry<'this>
+    where
+        Self: 'this;
+
+    fn entry(&mut self) -> Self::Entry<'_>;
+}
+
+impl<T> OptionEntry for Option<T> {
+    type Entry<'this> = Entry<'this, T> where T: 'this;
+
+    fn entry(&mut self) -> Self::Entry<'_> {
+        match OptionBucket::new(self) {
+            OptionBucket::Some(inner) => Entry::Occupied(OccupiedEntry { inner }),
+            OptionBucket::None(inner) => Entry::Vacant(VacantEntry { inner }),
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let mut even: Option<i32> = None;
+
+    for n in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] {
+        if n % 2 == 0 {
+            even.entry().and_modify(|x| *x += 1).or_insert(1);
+        }
+    }
+
+    match even.entry() {
+        Entry::Occupied(mut entry) => {
+            assert_eq!(entry.get(), &5);
+            assert_eq!(entry.insert(-3), 5);
+            assert_eq!(entry.remove(), -3);
+        }
+        Entry::Vacant(_) => unreachable!(),
+    }
+    assert!(even.is_none());
+
+    let day_hours = 24;
+
+    let mut x = None;
+    x.entry().or_insert_with(|| day_hours * 60 * 60 * 1000);
+    assert_eq!(x, Some(86_400_000));
+
+    let mut y: Option<u32> = None;
+    y.entry().or_default();
+    assert_eq!(y, Some(0));
+}

--- a/src/storage/boolean.rs
+++ b/src/storage/boolean.rs
@@ -146,11 +146,11 @@ impl ExactSizeIterator for Keys {
 }
 
 impl<V> Storage<bool, V> for BooleanStorage<V> {
-    type Iter<'this> = Iter<'this, V> where Self: 'this;
-    type Keys<'this> = Keys where Self: 'this;
-    type Values<'this> = Values<'this, V> where Self: 'this;
-    type IterMut<'this> = IterMut<'this, V> where Self: 'this;
-    type ValuesMut<'this> = ValuesMut<'this, V> where Self: 'this;
+    type Iter<'this> = Iter<'this, V> where V: 'this;
+    type Keys<'this> = Keys where V: 'this;
+    type Values<'this> = Values<'this, V> where V: 'this;
+    type IterMut<'this> = IterMut<'this, V> where V: 'this;
+    type ValuesMut<'this> = ValuesMut<'this, V> where V: 'this;
     type IntoIter = IntoIter<V>;
 
     #[inline]

--- a/src/storage/entry/boolean.rs
+++ b/src/storage/entry/boolean.rs
@@ -1,50 +1,58 @@
 #![allow(clippy::match_bool)]
 
+use crate::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 use crate::storage::entry;
 use crate::storage::BooleanStorage;
-use entry::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 
-pub struct VacantEntry<'this, V> {
+pub struct VacantEntry<'a, V> {
     key: bool,
-    inner: NoneBucket<'this, V>,
+    inner: NoneBucket<'a, V>,
 }
 
-pub struct OccupiedEntry<'this, V> {
+pub struct OccupiedEntry<'a, V> {
     key: bool,
-    inner: SomeBucket<'this, V>,
+    inner: SomeBucket<'a, V>,
 }
 
-impl<'this, V> entry::VacantEntry<'this, bool, V> for VacantEntry<'this, V> {
+impl<'a, V> entry::VacantEntry<'a, bool, V> for VacantEntry<'a, V> {
+    #[inline]
     fn key(&self) -> bool {
         self.key
     }
 
-    fn insert(self, value: V) -> &'this mut V {
+    #[inline]
+    fn insert(self, value: V) -> &'a mut V {
         self.inner.insert(value)
     }
 }
 
-impl<'this, V> entry::OccupiedEntry<'this, bool, V> for OccupiedEntry<'this, V> {
+impl<'a, V> entry::OccupiedEntry<'a, bool, V> for OccupiedEntry<'a, V> {
+    #[inline]
     fn key(&self) -> bool {
         self.key
     }
 
+    #[inline]
     fn get(&self) -> &V {
         self.inner.as_ref()
     }
 
+    #[inline]
     fn get_mut(&mut self) -> &mut V {
         self.inner.as_mut()
     }
 
-    fn into_mut(self) -> &'this mut V {
+    #[inline]
+    fn into_mut(self) -> &'a mut V {
         self.inner.into_mut()
     }
 
+    #[inline]
     fn insert(&mut self, value: V) -> V {
         self.inner.replace(value)
     }
 
+    #[inline]
     fn remove(self) -> V {
         self.inner.take()
     }
@@ -55,7 +63,7 @@ impl<V> entry::StorageEntry<bool, V> for BooleanStorage<V> {
     type Vacant<'this> = VacantEntry<'this, V> where V: 'this;
 
     #[inline]
-    fn entry(&mut self, key: bool) -> entry::Entry<Self::Occupied<'_>, Self::Vacant<'_>> {
+    fn entry(&mut self, key: bool) -> entry::Entry<'_, Self, bool, V> {
         match key {
             true => match OptionBucket::new(&mut self.t) {
                 OptionBucket::Some(inner) => entry::Entry::Occupied(OccupiedEntry { key, inner }),

--- a/src/storage/entry/map.rs
+++ b/src/storage/entry/map.rs
@@ -3,55 +3,70 @@ use core::hash::Hash;
 use crate::storage::entry;
 use crate::storage::MapStorage;
 
-use ::hashbrown::hash_map::DefaultHashBuilder as S;
+type S = ::hashbrown::hash_map::DefaultHashBuilder;
 type OccupiedEntry<'this, K, V> = ::hashbrown::hash_map::OccupiedEntry<'this, K, V, S>;
 type VacantEntry<'this, K, V> = ::hashbrown::hash_map::VacantEntry<'this, K, V, S>;
 type HEntry<'this, K, V> = ::hashbrown::hash_map::Entry<'this, K, V, S>;
 
-impl<'this, K: Copy + Eq + Hash, V> entry::OccupiedEntry<'this, K, V>
-    for OccupiedEntry<'this, K, V>
+impl<'this, K, V> entry::OccupiedEntry<'this, K, V> for OccupiedEntry<'this, K, V>
+where
+    K: Copy + Eq + Hash,
 {
+    #[inline]
     fn key(&self) -> K {
         *self.key()
     }
 
+    #[inline]
     fn get(&self) -> &V {
         self.get()
     }
 
+    #[inline]
     fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
 
+    #[inline]
     fn into_mut(self) -> &'this mut V {
         self.into_mut()
     }
 
+    #[inline]
     fn insert(&mut self, value: V) -> V {
         self.insert(value)
     }
 
+    #[inline]
     fn remove(self) -> V {
         self.remove()
     }
 }
 
-impl<'this, K: Copy + Eq + Hash, V> entry::VacantEntry<'this, K, V> for VacantEntry<'this, K, V> {
+impl<'this, K, V> entry::VacantEntry<'this, K, V> for VacantEntry<'this, K, V>
+where
+    K: Copy + Eq + Hash,
+{
+    #[inline]
     fn key(&self) -> K {
         *self.key()
     }
 
+    #[inline]
     fn insert(self, value: V) -> &'this mut V {
         self.insert(value)
     }
 }
 
-impl<K: Copy + Eq + Hash, V> entry::StorageEntry<K, V> for MapStorage<K, V> {
+impl<K, V> entry::StorageEntry<K, V> for MapStorage<K, V>
+where
+    K: Copy + Eq + Hash,
+{
     type Occupied<'this> = OccupiedEntry<'this, K, V> where K: 'this, V: 'this;
     type Vacant<'this> = VacantEntry<'this, K, V> where K: 'this, V: 'this;
 
     #[inline]
-    fn entry(&mut self, key: K) -> entry::Entry<Self::Occupied<'_>, Self::Vacant<'_>> {
+    fn entry(&mut self, key: K) -> entry::Entry<'_, Self, K, V> {
         match self.inner.entry(key) {
             HEntry::Occupied(entry) => entry::Entry::Occupied(entry),
             HEntry::Vacant(entry) => entry::Entry::Vacant(entry),

--- a/src/storage/entry/map.rs
+++ b/src/storage/entry/map.rs
@@ -4,13 +4,13 @@ use crate::storage::entry;
 use crate::storage::MapStorage;
 
 type S = ::hashbrown::hash_map::DefaultHashBuilder;
-type OccupiedEntry<'this, K, V> = ::hashbrown::hash_map::OccupiedEntry<'this, K, V, S>;
-type VacantEntry<'this, K, V> = ::hashbrown::hash_map::VacantEntry<'this, K, V, S>;
-type HEntry<'this, K, V> = ::hashbrown::hash_map::Entry<'this, K, V, S>;
+type OccupiedEntry<'a, K, V> = ::hashbrown::hash_map::OccupiedEntry<'a, K, V, S>;
+type VacantEntry<'a, K, V> = ::hashbrown::hash_map::VacantEntry<'a, K, V, S>;
+type HEntry<'a, K, V> = ::hashbrown::hash_map::Entry<'a, K, V, S>;
 
-impl<'this, K, V> entry::OccupiedEntry<'this, K, V> for OccupiedEntry<'this, K, V>
+impl<'a, K, V> entry::OccupiedEntry<'a, K, V> for OccupiedEntry<'a, K, V>
 where
-    K: Copy + Eq + Hash,
+    K: Copy,
 {
     #[inline]
     fn key(&self) -> K {
@@ -28,7 +28,7 @@ where
     }
 
     #[inline]
-    fn into_mut(self) -> &'this mut V {
+    fn into_mut(self) -> &'a mut V {
         self.into_mut()
     }
 
@@ -45,7 +45,7 @@ where
 
 impl<'this, K, V> entry::VacantEntry<'this, K, V> for VacantEntry<'this, K, V>
 where
-    K: Copy + Eq + Hash,
+    K: Copy + Hash,
 {
     #[inline]
     fn key(&self) -> K {

--- a/src/storage/entry/singleton.rs
+++ b/src/storage/entry/singleton.rs
@@ -12,7 +12,7 @@ pub struct OccupiedEntry<'a, V> {
 
 impl<'a, K, V> entry::VacantEntry<'a, K, V> for VacantEntry<'a, V>
 where
-    K: Copy + Default,
+    K: Default,
 {
     #[inline]
     fn key(&self) -> K {
@@ -25,7 +25,10 @@ where
     }
 }
 
-impl<'a, K: Copy + Default, V> entry::OccupiedEntry<'a, K, V> for OccupiedEntry<'a, V> {
+impl<'a, K, V> entry::OccupiedEntry<'a, K, V> for OccupiedEntry<'a, V>
+where
+    K: Default,
+{
     #[inline]
     fn key(&self) -> K {
         K::default()
@@ -59,7 +62,7 @@ impl<'a, K: Copy + Default, V> entry::OccupiedEntry<'a, K, V> for OccupiedEntry<
 
 impl<K, V> entry::StorageEntry<K, V> for SingletonStorage<V>
 where
-    K: Copy + Default,
+    K: Default,
 {
     type Occupied<'this> = OccupiedEntry<'this, V> where V: 'this;
     type Vacant<'this> = VacantEntry<'this, V> where V: 'this;

--- a/src/storage/entry/singleton.rs
+++ b/src/storage/entry/singleton.rs
@@ -1,57 +1,71 @@
+use crate::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 use crate::storage::entry;
 use crate::storage::SingletonStorage;
-use entry::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 
-pub struct VacantEntry<'this, V> {
-    inner: NoneBucket<'this, V>,
+pub struct VacantEntry<'a, V> {
+    inner: NoneBucket<'a, V>,
 }
 
-pub struct OccupiedEntry<'this, V> {
-    inner: SomeBucket<'this, V>,
+pub struct OccupiedEntry<'a, V> {
+    inner: SomeBucket<'a, V>,
 }
 
-impl<'this, K: Copy + Default, V> entry::VacantEntry<'this, K, V> for VacantEntry<'this, V> {
+impl<'a, K, V> entry::VacantEntry<'a, K, V> for VacantEntry<'a, V>
+where
+    K: Copy + Default,
+{
+    #[inline]
     fn key(&self) -> K {
         K::default()
     }
 
-    fn insert(self, value: V) -> &'this mut V {
+    #[inline]
+    fn insert(self, value: V) -> &'a mut V {
         self.inner.insert(value)
     }
 }
 
-impl<'this, K: Copy + Default, V> entry::OccupiedEntry<'this, K, V> for OccupiedEntry<'this, V> {
+impl<'a, K: Copy + Default, V> entry::OccupiedEntry<'a, K, V> for OccupiedEntry<'a, V> {
+    #[inline]
     fn key(&self) -> K {
         K::default()
     }
 
+    #[inline]
     fn get(&self) -> &V {
         self.inner.as_ref()
     }
 
+    #[inline]
     fn get_mut(&mut self) -> &mut V {
         self.inner.as_mut()
     }
 
-    fn into_mut(self) -> &'this mut V {
+    #[inline]
+    fn into_mut(self) -> &'a mut V {
         self.inner.into_mut()
     }
 
+    #[inline]
     fn insert(&mut self, value: V) -> V {
         self.inner.replace(value)
     }
 
+    #[inline]
     fn remove(self) -> V {
         self.inner.take()
     }
 }
 
-impl<K: Copy + Default, V> entry::StorageEntry<K, V> for SingletonStorage<V> {
+impl<K, V> entry::StorageEntry<K, V> for SingletonStorage<V>
+where
+    K: Copy + Default,
+{
     type Occupied<'this> = OccupiedEntry<'this, V> where V: 'this;
     type Vacant<'this> = VacantEntry<'this, V> where V: 'this;
 
     #[inline]
-    fn entry(&mut self, _key: K) -> entry::Entry<Self::Occupied<'_>, Self::Vacant<'_>> {
+    fn entry(&mut self, _key: K) -> entry::Entry<'_, Self, K, V> {
         match OptionBucket::new(&mut self.inner) {
             OptionBucket::Some(inner) => entry::Entry::Occupied(OccupiedEntry { inner }),
             OptionBucket::None(inner) => entry::Entry::Vacant(VacantEntry { inner }),

--- a/src/storage/map.rs
+++ b/src/storage/map.rs
@@ -1,4 +1,4 @@
-use core::hash;
+use core::hash::Hash;
 use core::iter;
 
 use crate::storage::Storage;
@@ -45,7 +45,7 @@ where
 
 impl<K, V> Default for MapStorage<K, V>
 where
-    K: Eq + hash::Hash,
+    K: Hash,
 {
     #[inline]
     fn default() -> Self {
@@ -57,25 +57,25 @@ where
 
 impl<K, V> PartialEq for MapStorage<K, V>
 where
-    K: Eq + hash::Hash,
+    K: Eq + Hash,
     V: PartialEq,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
+        self.inner.eq(&other.inner)
     }
 }
 
 impl<K, V> Eq for MapStorage<K, V>
 where
-    K: Eq + hash::Hash,
+    K: Eq + Hash,
     V: Eq,
 {
 }
 
 impl<K, V> Storage<K, V> for MapStorage<K, V>
 where
-    K: Copy + Eq + hash::Hash,
+    K: Copy + Eq + Hash,
 {
     type Iter<'this> = iter::Map<::hashbrown::hash_map::Iter<'this, K, V>, fn((&'this K, &'this V)) -> (K, &'this V)> where K: 'this, V: 'this;
     type Keys<'this> = iter::Copied<::hashbrown::hash_map::Keys<'this, K, V>> where K: 'this, V: 'this;

--- a/src/storage/map.rs
+++ b/src/storage/map.rs
@@ -77,11 +77,11 @@ impl<K, V> Storage<K, V> for MapStorage<K, V>
 where
     K: Copy + Eq + hash::Hash,
 {
-    type Iter<'this> = iter::Map<::hashbrown::hash_map::Iter<'this, K, V>, fn((&'this K, &'this V)) -> (K, &'this V)> where Self: 'this, V: 'this;
-    type Keys<'this> = iter::Copied<::hashbrown::hash_map::Keys<'this, K, V>> where Self: 'this;
-    type Values<'this> = ::hashbrown::hash_map::Values<'this, K, V> where Self: 'this;
-    type IterMut<'this> = iter::Map<::hashbrown::hash_map::IterMut<'this, K, V>, fn((&'this K, &'this mut V)) -> (K, &'this mut V)> where Self: 'this, V: 'this;
-    type ValuesMut<'this> = ::hashbrown::hash_map::ValuesMut<'this, K, V> where Self: 'this;
+    type Iter<'this> = iter::Map<::hashbrown::hash_map::Iter<'this, K, V>, fn((&'this K, &'this V)) -> (K, &'this V)> where K: 'this, V: 'this;
+    type Keys<'this> = iter::Copied<::hashbrown::hash_map::Keys<'this, K, V>> where K: 'this, V: 'this;
+    type Values<'this> = ::hashbrown::hash_map::Values<'this, K, V> where K: 'this, V: 'this;
+    type IterMut<'this> = iter::Map<::hashbrown::hash_map::IterMut<'this, K, V>, fn((&'this K, &'this mut V)) -> (K, &'this mut V)> where K: 'this, V: 'this;
+    type ValuesMut<'this> = ::hashbrown::hash_map::ValuesMut<'this, K, V> where K: 'this, V: 'this;
     type IntoIter = ::hashbrown::hash_map::IntoIter<K, V>;
 
     #[inline]

--- a/src/storage/option.rs
+++ b/src/storage/option.rs
@@ -75,8 +75,8 @@ where
 impl<K, V> Clone for OptionStorage<K, V>
 where
     K: Key,
-    K::Storage<V>: Clone,
     V: Clone,
+    K::Storage<V>: Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -89,8 +89,8 @@ where
 impl<K, V> Copy for OptionStorage<K, V>
 where
     K: Key,
-    K::Storage<V>: Copy,
     V: Copy,
+    K::Storage<V>: Copy,
 {
 }
 

--- a/src/storage/option.rs
+++ b/src/storage/option.rs
@@ -130,11 +130,11 @@ impl<K, V> Storage<Option<K>, V> for OptionStorage<K, V>
 where
     K: Key,
 {
-    type Iter<'this> = Iter<'this, K, V> where Self: 'this;
-    type Keys<'this> = Keys<'this, K, V> where Self: 'this;
-    type Values<'this> = Values<'this, K, V> where Self: 'this;
-    type IterMut<'this> = IterMut<'this, K, V> where Self: 'this;
-    type ValuesMut<'this> = ValuesMut<'this, K, V> where Self: 'this;
+    type Iter<'this> = Iter<'this, K, V> where K: 'this, V: 'this;
+    type Keys<'this> = Keys<'this, K, V> where K: 'this, V: 'this;
+    type Values<'this> = Values<'this, K, V> where K: 'this, V: 'this;
+    type IterMut<'this> = IterMut<'this, K, V> where K: 'this, V: 'this;
+    type ValuesMut<'this> = ValuesMut<'this, K, V> where K: 'this, V: 'this;
     type IntoIter = IntoIter<K, V>;
 
     #[inline]

--- a/src/storage/singleton.rs
+++ b/src/storage/singleton.rs
@@ -34,11 +34,11 @@ impl<K, V> Storage<K, V> for SingletonStorage<V>
 where
     K: Copy + Default,
 {
-    type Iter<'this> = ::core::option::IntoIter<(K, &'this V)> where Self: 'this, V: 'this;
-    type Keys<'this> = ::core::option::IntoIter<K> where Self: 'this;
-    type Values<'this> = ::core::option::Iter<'this, V> where Self: 'this, V: 'this;
-    type IterMut<'this> = ::core::option::IntoIter<(K, &'this mut V)> where Self: 'this, V: 'this;
-    type ValuesMut<'this> = ::core::option::IterMut<'this, V> where Self: 'this, V: 'this;
+    type Iter<'this> = ::core::option::IntoIter<(K, &'this V)> where V: 'this;
+    type Keys<'this> = ::core::option::IntoIter<K> where V: 'this;
+    type Values<'this> = ::core::option::Iter<'this, V> where V: 'this;
+    type IterMut<'this> = ::core::option::IntoIter<(K, &'this mut V)> where V: 'this;
+    type ValuesMut<'this> = ::core::option::IterMut<'this, V> where V: 'this;
     type IntoIter = ::core::option::IntoIter<(K, V)>;
 
     #[inline]

--- a/src/storage/singleton.rs
+++ b/src/storage/singleton.rs
@@ -32,7 +32,7 @@ impl<V> Eq for SingletonStorage<V> where V: Eq {}
 
 impl<K, V> Storage<K, V> for SingletonStorage<V>
 where
-    K: Copy + Default,
+    K: Default,
 {
     type Iter<'this> = ::core::option::IntoIter<(K, &'this V)> where V: 'this;
     type Keys<'this> = ::core::option::IntoIter<K> where V: 'this;


### PR DESCRIPTION
Mostly style nits to try and make everything roughly abide by same conventions, which are:
* Lifetimes associated with structs and impls are named `'a`, lifetimes associated with GATs are named `'this`.
* In macros, use `#lt` for lifetimes and always use [fully qualified function calling](https://doc.rust-lang.org/reference/expressions/call-expr.html#disambiguating-function-calls) to avoid any possibilities of ambiguities.

Lots and lots of `#[inline]`. I'll add benchmarks next.

While reviewing looking through the entry API the bounds on the `Entry` enum functions made me a bit unhappy since they're essentially constrained on the function call and leaves the door open for confusing constraint errors.

I've reworked the `Entry` enum to take an `<'a, S, K, V> where S: StorageEntry<K, V>`. This ensures that `Entry` use is type constrained as it's being constructed, rather than as a method on it is being called.