### PR TITLE
Introduce SetStorage and clean up derives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with: { toolchain: beta, override: true, profile: minimal }
     # Test all relevant feature combos:
-    # features: std, map, entry, serde
+    # features: std, hashbrown, entry, serde
     - run: cargo test --all-features
-    # features: -std, -map, -entry, -serde
+    # features: -std, -hashbrown, -entry, -serde
     - run: cargo test --no-default-features
-    # features: -std, -map, -entry, serde
+    # features: -std, -hashbrown, -entry, serde
     - run: cargo test --no-default-features --features serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ categories = ["data-structures"]
 all-features = true
 
 [features]
-default = ["map", "std"]
+default = ["hashbrown", "std"]
 std = ["serde?/std"]
-map = ["hashbrown", "std"]
 
 [dependencies]
 fixed-map-derive = { version = "0.8.0-alpha.2", path = "fixed-map-derive" }

--- a/benches/complex.rs
+++ b/benches/complex.rs
@@ -20,7 +20,7 @@ macro_rules! benches {
 
             // Assert that size of Key is identical to array.
             const _: () = assert!(
-                mem::size_of::<<Key as fixed_map::key::Key>::Storage<usize>>() == mem::size_of::<[Option<usize>; $len]>()
+                mem::size_of::<<Key as fixed_map::key::Key>::MapStorage<usize>>() == mem::size_of::<[Option<usize>; $len]>()
             );
 
             group.bench_with_input(BenchmarkId::new("fixed", $len), &$len, |b: &mut Bencher, _| {

--- a/examples/composite.rs
+++ b/examples/composite.rs
@@ -1,0 +1,23 @@
+use fixed_map::{Key, Map};
+
+#[derive(Clone, Copy, Key)]
+enum Part {
+    One,
+    Two,
+}
+
+#[derive(Clone, Copy, Key)]
+enum Key {
+    Simple,
+    Composite(Part),
+    Number(u32),
+    Singleton(()),
+    String(&'static str),
+}
+
+fn main() {
+    let mut map = Map::new();
+    map.insert(Key::Number(42), 42);
+    assert_eq!(map.get(Key::Number(42)), Some(&42));
+    assert_eq!(map.get(Key::Simple), None);
+}

--- a/examples/composite.rs
+++ b/examples/composite.rs
@@ -10,14 +10,12 @@ enum Part {
 enum Key {
     Simple,
     Composite(Part),
-    Number(u32),
     Singleton(()),
-    String(&'static str),
 }
 
 fn main() {
     let mut map = Map::new();
-    map.insert(Key::Number(42), 42);
-    assert_eq!(map.get(Key::Number(42)), Some(&42));
+    map.insert(Key::Composite(Part::One), 42);
+    assert_eq!(map.get(Key::Composite(Part::One)), Some(&42));
     assert_eq!(map.get(Key::Simple), None);
 }

--- a/fixed-map-derive/Cargo.toml
+++ b/fixed-map-derive/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["container", "data-structure", "map", "no_std"]
 categories = ["data-structures"]
 
 [dependencies]
-syn = "1.0.8"
+syn = { version = "1.0.8", features = ["full"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 

--- a/fixed-map-derive/src/any_variants.rs
+++ b/fixed-map-derive/src/any_variants.rs
@@ -1,74 +1,40 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
-use syn::{DataEnum, Fields, Ident};
+use syn::{DataEnum, Ident, Pat};
 
-use crate::context::{Ctxt, FieldKind, FieldSpec};
+const MAP_STORAGE: &str = "__MapStorage";
+const SET_STORAGE: &str = "__SetStorage";
 
+use crate::context::Ctxt;
+
+///
 pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()> {
-    let vis = &cx.ast.vis;
     let ident = &cx.ast.ident;
-    let lt = cx.lt;
 
-    let clone_t = cx.toks.clone_t();
-    let copy_t = cx.toks.copy_t();
-    let eq_t = cx.toks.eq_t();
     let key_t = cx.toks.key_t();
-    let mem = cx.toks.mem();
-    let option = cx.toks.option();
-    let partial_eq_t = cx.toks.partial_eq_t();
     let storage_t = cx.toks.storage_t();
+    let set_storage_t = cx.toks.set_storage_t();
 
     let const_wrapper = Ident::new(
         &format!("__IMPL_KEY_FOR_{}", cx.ast.ident),
         Span::call_site(),
     );
 
-    let mut len = Vec::new();
-    let mut is_empty = Vec::new();
-    let mut pattern = Vec::new();
-    let mut fields = Vec::new();
-    let mut field_inits = Vec::new();
-    let mut contains_key = Vec::new();
-    let mut get = Vec::new();
-    let mut get_mut = Vec::new();
-    let mut insert = Vec::new();
-    let mut remove = Vec::new();
-    let mut retain = Vec::new();
-    let mut clear = Vec::new();
-    let mut copy_bounds = Vec::new();
-    let mut field_specs = Vec::new();
-    let mut names = Vec::new();
+    let mut fields = Fields::default();
 
     for (index, variant) in en.variants.iter().enumerate() {
         let var = &variant.ident;
         let name = format_ident!("_{}", index);
-        names.push(name.clone());
 
         let kind = match &variant.fields {
-            Fields::Unit => {
-                field_inits.push(quote!(#option::None));
-                len.push(quote!(usize::from(#option::is_some(&self.#name))));
-                is_empty.push(quote!(#option::is_none(&self.#name)));
-                fields.push(quote!(#option<V>));
-                pattern.push(quote!(#ident::#var));
-                clear.push(quote!(self.#name = #option::None));
-                contains_key.push(quote!(#option::is_some(&self.#name)));
-                get.push(quote!(#option::as_ref(&self.#name)));
-                get_mut.push(quote!(#option::as_mut(&mut self.#name)));
-                insert.push(quote!(#mem::replace(&mut self.#name, #option::Some(value))));
-                remove.push(quote!(#mem::replace(&mut self.#name, #option::None)));
-                retain.push(quote! {
-                    if let #option::Some(val) = #option::as_mut(&mut self.#name) {
-                        if !func(#ident::#var, val) {
-                            self.#name = None;
-                        }
-                    }
-                });
-
-                FieldKind::Simple
+            syn::Fields::Unit => {
+                fields
+                    .patterns
+                    .push(cx.fallible(|| syn::parse2(quote!(#ident::#var)))?);
+                Kind::Simple
             }
-            Fields::Unnamed(unnamed) => {
+            syn::Fields::Unnamed(unnamed) => {
                 if unnamed.unnamed.len() > 1 {
                     cx.error(
                         variant.fields.span(),
@@ -80,38 +46,28 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
                 let element = unnamed.unnamed.first().expect("Expected one element");
                 let storage = quote!(<#element as #key_t>::Storage::<V>);
                 let as_storage = quote!(<#storage as #storage_t<#element, V>>);
+                let set_storage = quote!(<#element as #key_t>::SetStorage);
+                let as_set_storage = quote!(<#set_storage as #set_storage_t<#element>>);
 
-                field_inits.push(quote!(#as_storage::empty()));
-                len.push(quote!(#as_storage::len(&self.#name)));
-                is_empty.push(quote!(#as_storage::is_empty(&self.#name)));
+                fields
+                    .patterns
+                    .push(cx.fallible(|| syn::parse2(quote!(#ident::#var(v))))?);
 
-                fields.push(quote!(#storage));
-                pattern.push(quote!(#ident::#var(v)));
-                clear.push(quote!(#as_storage::clear(&mut self.#name)));
-                contains_key.push(quote!(#as_storage::contains_key(&self.#name, v)));
-                get.push(quote!(#as_storage::get(&self.#name, v)));
-                get_mut.push(quote!(#as_storage::get_mut(&mut self.#name, v)));
-                insert.push(quote!(#as_storage::insert(&mut self.#name, v, value)));
-                remove.push(quote!(#as_storage::remove(&mut self.#name, v)));
-                retain.push(quote! {
-                    #as_storage::retain(&mut self.#name, |k, v| func(#ident::#var(k), v));
-                });
-
-                copy_bounds.push(storage.clone());
-
-                FieldKind::Complex {
-                    element: quote!(#element),
+                Kind::Complex(Complex {
+                    element,
                     storage,
                     as_storage,
-                }
+                    set_storage,
+                    as_set_storage,
+                })
             }
-            Fields::Named(_) => {
+            syn::Fields::Named(_) => {
                 cx.error(variant.fields.span(), "named fields are not supported");
                 continue;
             }
         };
 
-        field_specs.push(FieldSpec {
+        fields.fields.push(Field {
             span: variant.span(),
             index,
             name,
@@ -120,203 +76,548 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
         });
     }
 
-    let mut iter_clone = Vec::new();
-
-    for FieldSpec { name, .. } in &field_specs {
-        iter_clone.push(quote!(#name: #clone_t::clone(&self.#name)));
-    }
-
-    let pattern = &pattern;
-
-    let (iter_impl, iter_init) = build_iter_impl(cx, "Iter", &field_specs)?;
-    let (keys_impl, keys_iter_init) = build_keys_impl(cx, "Keys", &field_specs)?;
-    let (values_impl, values_iter_init) = build_values_impl(cx, "Values", &field_specs)?;
-    let (iter_mut_impl, iter_mut_init) = build_iter_mut_impl(cx, "IterMut", &field_specs)?;
-    let (values_mut_impl, values_mut_init) = build_values_mut_impl(cx, "ValuesMut", &field_specs)?;
-    let (into_iter_impl, into_iter_init) = build_into_iter_impl(cx, "IntoIter", &field_specs)?;
-    let (entry_impl, entry_items_impl) = build_entry_impl(cx, &field_specs)?;
-
-    let end = field_specs.len();
+    let (map_storage_type_name, map_storage_impl) = impl_map_storage(cx, &fields)?;
+    let (set_storage_type_name, set_storage_impl) = impl_set_storage(cx, &fields)?;
 
     Ok(quote! {
         const #const_wrapper: () = {
-            #vis struct Storage<V> {
-                #(#names: #fields,)*
+            #map_storage_impl
+            #set_storage_impl
+
+            #[automatically_derived]
+            impl #key_t for #ident {
+                type Storage<V> = #map_storage_type_name<V>;
+                type SetStorage = #set_storage_type_name;
+            }
+        };
+    })
+}
+
+/// Implement `Storage` implementation.
+fn impl_map_storage(cx: &Ctxt<'_>, fields: &Fields<'_>) -> Result<(Ident, TokenStream), ()> {
+    let vis = &cx.ast.vis;
+    let ident = &cx.ast.ident;
+
+    let mem = cx.toks.mem();
+    let option = cx.toks.option();
+    let storage_t = cx.toks.storage_t();
+
+    let type_name = format_ident!("{MAP_STORAGE}");
+
+    let mut output = Output::default();
+
+    map_storage_iter(cx, "Iter", fields, &mut output)?;
+    map_storage_keys(cx, "Keys", fields, &mut output)?;
+    map_storage_values(cx, "Values", fields, &mut output)?;
+    map_storage_iter_mut(cx, "IterMut", fields, &mut output)?;
+    map_storage_values_mut(cx, "ValuesMut", fields, &mut output)?;
+    map_storage_into_iter(cx, "IntoIter", fields, &mut output)?;
+    map_storage_entry(cx, fields, &type_name, &mut output)?;
+
+    {
+        let partial_eq_t = cx.toks.partial_eq_t();
+        let eq_t = cx.toks.eq_t();
+        let names = fields.names();
+
+        output.impls.extend(quote! {
+            #[automatically_derived]
+            impl<V> #partial_eq_t for #type_name<V> where V: #partial_eq_t {
+                #[inline]
+                fn eq(&self, other: &Self) -> bool {
+                    #(if #partial_eq_t::ne(&self.#names, &other.#names) {
+                        return false;
+                    })*
+
+                    true
+                }
             }
 
             #[automatically_derived]
-            impl<V> #clone_t for Storage<V> where V: #clone_t {
+            impl<V> #eq_t for #type_name<V> where V: #eq_t {}
+        });
+    }
+
+    {
+        let clone_t = cx.toks.clone_t();
+        let copy_t = cx.toks.copy_t();
+        let bounds = fields.complex().map(|Complex { storage, .. }| storage);
+        let names = fields.names();
+
+        output.impls.extend(quote! {
+            #[automatically_derived]
+            impl<V> #clone_t for #type_name<V> where V: #clone_t {
                 #[inline]
-                fn clone(&self) -> Storage<V> {
-                    Storage {
+                fn clone(&self) -> Self {
+                    Self {
                         #(#names: #clone_t::clone(&self.#names),)*
                     }
                 }
             }
 
             #[automatically_derived]
-            impl<V> #copy_t for Storage<V> where V: #copy_t, #(#copy_bounds: #copy_t,)* {}
+            impl<V> #copy_t for #type_name<V> where V: #copy_t, #(#bounds: #copy_t,)* {}
+        });
+    }
 
+    {
+        let inits = fields.iter().map(|f| match &f.kind {
+            Kind::Complex(Complex { as_storage, .. }) => quote!(#as_storage::empty()),
+            Kind::Simple => quote!(#option::None),
+        });
+
+        let names = fields.names();
+
+        output.items.extend(quote! {
+            #[inline]
+            fn empty() -> Self {
+                Self {
+                    #(#names: #inits,)*
+                }
+            }
+        });
+    }
+
+    {
+        let patterns = &fields.patterns;
+
+        let insert = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::insert(&mut self.#name, v, value))
+            }
+            Kind::Simple => quote!(#mem::replace(&mut self.#name, #option::Some(value))),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn insert(&mut self, key: #ident, value: V) -> #option<V> {
+                match key {
+                    #(#patterns => #insert,)*
+                }
+            }
+        });
+    }
+
+    {
+        let len = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::len(&self.#name))
+            }
+            Kind::Simple => quote!(usize::from(#option::is_some(&self.#name))),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn len(&self) -> usize {
+                0 #(+ #len)*
+            }
+        });
+    }
+
+    {
+        let is_empty = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::is_empty(&self.#name))
+            }
+            Kind::Simple => quote!(#option::is_none(&self.#name)),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn is_empty(&self) -> bool {
+                true #(&& #is_empty)*
+            }
+        });
+    }
+
+    {
+        let patterns = &fields.patterns;
+
+        let contains_key = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::contains_key(&self.#name, v))
+            }
+            Kind::Simple => quote!(#option::is_some(&self.#name)),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn contains_key(&self, value: #ident) -> bool {
+                match value {
+                    #(#patterns => #contains_key,)*
+                }
+            }
+        });
+    }
+
+    {
+        let patterns = &fields.patterns;
+
+        let get = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::get(&self.#name, v))
+            }
+            Kind::Simple => quote!(#option::as_ref(&self.#name)),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn get(&self, value: #ident) -> #option<&V> {
+                match value {
+                    #(#patterns => #get,)*
+                }
+            }
+        });
+    }
+
+    {
+        let patterns = &fields.patterns;
+
+        let get_mut = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::get_mut(&mut self.#name, v))
+            }
+            Kind::Simple => quote!(#option::as_mut(&mut self.#name)),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn get_mut(&mut self, value: #ident) -> #option<&mut V> {
+                match value {
+                    #(#patterns => #get_mut,)*
+                }
+            }
+        });
+    }
+
+    {
+        let remove = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => {
+                quote!(#as_storage::remove(&mut self.#name, v))
+            }
+            Kind::Simple => quote!(#mem::replace(&mut self.#name, #option::None)),
+        });
+
+        let patterns = &fields.patterns;
+
+        output.items.extend(quote! {
+            #[inline]
+            fn remove(&mut self, value: #ident) -> #option<V> {
+                match value {
+                    #(#patterns => #remove,)*
+                }
+            }
+        });
+    }
+
+    {
+        let retain = fields.iter().map(
+            |Field {
+                 var, name, kind, ..
+             }| match kind {
+                Kind::Complex(Complex { as_storage, .. }) => quote! {
+                    #as_storage::retain(&mut self.#name, |k, v| func(#ident::#var(k), v));
+                },
+                Kind::Simple => quote! {
+                    if let #option::Some(val) = #option::as_mut(&mut self.#name) {
+                        if !func(#ident::#var, val) {
+                            self.#name = None;
+                        }
+                    }
+                },
+            },
+        );
+
+        output.items.extend(quote! {
+            #[inline]
+            fn retain<F>(&mut self, mut func: F)
+            where
+                F: FnMut(#ident, &mut V) -> bool
+            {
+                #(#retain;)*
+            }
+        });
+    }
+
+    {
+        let clear = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_storage, .. }) => quote! {
+                #as_storage::clear(&mut self.#name)
+            },
+            Kind::Simple => quote! {
+                self.#name = #option::None
+            },
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn clear(&mut self) {
+                #(#clear;)*
+            }
+        });
+    }
+
+    let field_decls = fields.iter().map(|Field { name, kind, .. }| match kind {
+        Kind::Complex(Complex { storage, .. }) => quote!(#name: #storage),
+        Kind::Simple => quote!(#name: #option<V>),
+    });
+
+    let Output { impls, items } = output;
+
+    let map_storage_impl = quote! {
+        #vis struct #type_name<V> {
+            #(#field_decls,)*
+        }
+
+        #[automatically_derived]
+        impl<V> #storage_t<#ident, V> for #type_name<V> {
+            #items
+        }
+
+        #impls
+    };
+
+    Ok((type_name, map_storage_impl))
+}
+
+/// Implement `SetStorage` implementation.
+fn impl_set_storage(cx: &Ctxt<'_>, fields: &Fields<'_>) -> Result<(Ident, TokenStream), ()> {
+    let vis = &cx.ast.vis;
+    let ident = &cx.ast.ident;
+
+    let mem = cx.toks.mem();
+    let set_storage_t = cx.toks.set_storage_t();
+
+    let type_name = format_ident!("{SET_STORAGE}");
+
+    let mut output = Output::default();
+
+    set_storage_iter(cx, "Iter", fields, &mut output)?;
+    set_storage_into_iter(cx, "IntoIter", fields, &mut output)?;
+
+    {
+        let partial_eq_t = cx.toks.partial_eq_t();
+        let eq_t = cx.toks.eq_t();
+        let names = fields.names();
+
+        output.impls.extend(quote! {
             #[automatically_derived]
-            impl<V> #partial_eq_t for Storage<V> where V: #partial_eq_t {
+            impl #partial_eq_t for #type_name {
                 #[inline]
-                fn eq(&self, other: &Storage<V>) -> bool {
+                fn eq(&self, other: &Self) -> bool {
                     #(if #partial_eq_t::ne(&self.#names, &other.#names) {
                         return false;
                     })*
+
                     true
                 }
             }
 
             #[automatically_derived]
-            impl<V> #eq_t for Storage<V> where V: #eq_t {}
+            impl #eq_t for #type_name  {}
+        });
+    }
 
+    {
+        let clone_t = cx.toks.clone_t();
+        let copy_t = cx.toks.copy_t();
+        let bounds = fields
+            .complex()
+            .map(|Complex { set_storage, .. }| set_storage)
+            .collect::<Vec<_>>();
+        let names = fields.names();
+
+        output.impls.extend(quote! {
             #[automatically_derived]
-            impl<V> #storage_t<#ident, V> for Storage<V> {
-                type Iter<#lt> = Iter<#lt, V> where V: #lt;
-                type Keys<#lt> = Keys<#lt, V> where V: #lt;
-                type Values<#lt> = Values<#lt, V> where V: #lt;
-                type IterMut<#lt> = IterMut<#lt, V> where V: #lt;
-                type ValuesMut<#lt> = ValuesMut<#lt, V> where V: #lt;
-                type IntoIter = IntoIter<V>;
-
+            impl #clone_t for #type_name where #(for<'trivial_bounds> #bounds: #clone_t,)* {
                 #[inline]
-                fn empty() -> Self {
+                fn clone(&self) -> Self {
                     Self {
-                        #(#names: #field_inits,)*
+                        #(#names: #clone_t::clone(&self.#names),)*
                     }
                 }
-
-                #[inline]
-                fn len(&self) -> usize {
-                    #(#len)+*
-                }
-
-                #[inline]
-                fn is_empty(&self) -> bool {
-                    #(#is_empty)&&*
-                }
-
-                #[inline]
-                fn insert(&mut self, key: #ident, value: V) -> #option<V> {
-                    match key {
-                        #(#pattern => #insert,)*
-                    }
-                }
-
-                #[inline]
-                fn contains_key(&self, value: #ident) -> bool {
-                    match value {
-                        #(#pattern => #contains_key,)*
-                    }
-                }
-
-                #[inline]
-                fn get(&self, value: #ident) -> #option<&V> {
-                    match value {
-                        #(#pattern => #get,)*
-                    }
-                }
-
-                #[inline]
-                fn get_mut(&mut self, value: #ident) -> #option<&mut V> {
-                    match value {
-                        #(#pattern => #get_mut,)*
-                    }
-                }
-
-                #[inline]
-                fn remove(&mut self, value: #ident) -> #option<V> {
-                    match value {
-                        #(#pattern => #remove,)*
-                    }
-                }
-
-                #[inline]
-                fn retain<F>(&mut self, mut func: F)
-                where
-                    F: FnMut(#ident, &mut V) -> bool
-                {
-                    #(#retain)*
-                }
-
-                #[inline]
-                fn clear(&mut self) {
-                    #(#clear;)*
-                }
-
-                #[inline]
-                fn iter(&self) -> Self::Iter<'_> {
-                    Iter {
-                        start: 0,
-                        end: #end,
-                        #(#iter_init,)*
-                    }
-                }
-
-                #[inline]
-                fn keys(&self) -> Self::Keys<'_> {
-                    Keys {
-                        start: 0,
-                        end: #end,
-                        #(#keys_iter_init,)*
-                    }
-                }
-
-                #[inline]
-                fn values(&self) -> Self::Values<'_> {
-                    Values {
-                        start: 0,
-                        end: #end,
-                        #(#values_iter_init,)*
-                    }
-                }
-
-                #[inline]
-                fn iter_mut(&mut self) -> Self::IterMut<'_> {
-                    IterMut {
-                        start: 0,
-                        end: #end,
-                        #(#iter_mut_init,)*
-                    }
-                }
-
-                #[inline]
-                fn values_mut(&mut self) -> Self::ValuesMut<'_> {
-                    ValuesMut {
-                        start: 0,
-                        end: #end,
-                        #(#values_mut_init,)*
-                    }
-                }
-
-                #[inline]
-                fn into_iter(self) -> Self::IntoIter {
-                    IntoIter {
-                        start: 0,
-                        end: #end,
-                        #(#into_iter_init,)*
-                    }
-                }
-
-                #entry_items_impl
             }
 
             #[automatically_derived]
-            impl #key_t for #ident {
-                type Storage<V> = Storage<V>;
+            impl #copy_t for #type_name where #(for<'trivial_bounds> #bounds: #copy_t,)* {}
+        });
+    }
+
+    {
+        let inits = fields.iter().map(|f| match &f.kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => quote!(#as_set_storage::empty()),
+            Kind::Simple => quote!(false),
+        });
+
+        let names = fields.names();
+
+        output.items.extend(quote! {
+            #[inline]
+            fn empty() -> Self {
+                Self {
+                    #(#names: #inits,)*
+                }
             }
+        });
+    }
 
-            #iter_impl
-            #keys_impl
-            #values_impl
-            #iter_mut_impl
-            #values_mut_impl
-            #into_iter_impl
+    {
+        let patterns = &fields.patterns;
 
-            #entry_impl
-        };
-    })
+        let insert = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                quote!(#as_set_storage::insert(&mut self.#name, v))
+            }
+            Kind::Simple => quote!(!#mem::replace(&mut self.#name, true)),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn insert(&mut self, key: #ident) -> bool {
+                match key {
+                    #(#patterns => #insert,)*
+                }
+            }
+        });
+    }
+
+    {
+        let len = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                quote!(#as_set_storage::len(&self.#name))
+            }
+            Kind::Simple => quote!(usize::from(self.#name)),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn len(&self) -> usize {
+                0 #(+ #len)*
+            }
+        });
+    }
+
+    {
+        let is_empty = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                quote!(#as_set_storage::is_empty(&self.#name))
+            }
+            Kind::Simple => quote!(!self.#name),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn is_empty(&self) -> bool {
+                true #(&& #is_empty)*
+            }
+        });
+    }
+
+    {
+        let patterns = &fields.patterns;
+
+        let contains = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                quote!(#as_set_storage::contains(&self.#name, v))
+            }
+            Kind::Simple => quote!(self.#name),
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn contains(&self, value: #ident) -> bool {
+                match value {
+                    #(#patterns => #contains,)*
+                }
+            }
+        });
+    }
+
+    {
+        let remove = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                quote!(#as_set_storage::remove(&mut self.#name, v))
+            }
+            Kind::Simple => quote!(#mem::replace(&mut self.#name, false)),
+        });
+
+        let patterns = &fields.patterns;
+
+        output.items.extend(quote! {
+            #[inline]
+            fn remove(&mut self, value: #ident) -> bool {
+                match value {
+                    #(#patterns => #remove,)*
+                }
+            }
+        });
+    }
+
+    {
+        let retain = fields.iter().map(
+            |Field {
+                 var, name, kind, ..
+             }| match kind {
+                Kind::Complex(Complex { as_set_storage, .. }) => quote! {
+                    #as_set_storage::retain(&mut self.#name, |k| func(#ident::#var(k)));
+                },
+                Kind::Simple => quote! {
+                    if self.#name {
+                        self.#name = func(#ident::#var);
+                    }
+                },
+            },
+        );
+
+        output.items.extend(quote! {
+            #[inline]
+            fn retain<F>(&mut self, mut func: F)
+            where
+                F: FnMut(#ident) -> bool
+            {
+                #(#retain;)*
+            }
+        });
+    }
+
+    {
+        let clear = fields.iter().map(|Field { name, kind, .. }| match kind {
+            Kind::Complex(Complex { as_set_storage, .. }) => quote! {
+                #as_set_storage::clear(&mut self.#name)
+            },
+            Kind::Simple => quote! {
+                self.#name = false
+            },
+        });
+
+        output.items.extend(quote! {
+            #[inline]
+            fn clear(&mut self) {
+                #(#clear;)*
+            }
+        });
+    }
+
+    let field_decls = fields.iter().map(|Field { name, kind, .. }| match kind {
+        Kind::Complex(Complex { set_storage, .. }) => quote!(#name: #set_storage),
+        Kind::Simple => quote!(#name: bool),
+    });
+
+    let Output { impls, items } = output;
+
+    let map_storage_impl = quote! {
+        #vis struct #type_name {
+            #(#field_decls,)*
+        }
+
+        #[automatically_derived]
+        impl #set_storage_t<#ident> for #type_name {
+            #items
+        }
+
+        #impls
+    };
+
+    Ok((type_name, map_storage_impl))
 }
 
 /// Build iterator next.
@@ -324,7 +625,7 @@ fn build_iter_next(
     cx: &Ctxt<'_>,
     step_forward: &mut IteratorNext,
     step_backward: &mut IteratorNextBack,
-    field_specs: &[FieldSpec<'_>],
+    fields: &Fields<'_>,
     assoc_type: &Ident,
     lt: Option<&syn::Lifetime>,
 ) -> Result<(), ()> {
@@ -333,17 +634,17 @@ fn build_iter_next(
     let double_ended_iterator_t = cx.toks.double_ended_iterator_t();
     let ident = &cx.ast.ident;
 
-    for FieldSpec {
+    for Field {
         span,
         index,
         name,
         var,
         kind,
         ..
-    } in field_specs
+    } in fields
     {
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 step_forward.next.push(quote! {
                     #index => {
                         if let #option::Some(value) = #option::take(&mut self.#name) {
@@ -360,7 +661,7 @@ fn build_iter_next(
                     }
                 });
             }
-            FieldKind::Complex { as_storage, .. } => {
+            Kind::Complex(Complex { as_storage, .. }) => {
                 step_forward.next.push(quote! {
                     #index => {
                         if let #option::Some((key, value)) = #iterator_t::next(&mut self.#name) {
@@ -398,12 +699,14 @@ fn build_iter_next(
 }
 
 /// Construct an iterator implementation.
-fn build_iter_impl(
+fn map_storage_iter(
     cx: &Ctxt<'_>,
-    id: &str,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, Vec<TokenStream>), ()> {
-    let type_name = syn::Ident::new(id, Span::call_site());
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{MAP_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
 
     let lt = cx.lt;
     let ident = &cx.ast.ident;
@@ -417,7 +720,6 @@ fn build_iter_impl(
     let mut step_forward = IteratorNext::default();
     let mut step_backward = IteratorNextBack::default();
 
-    let mut iter_clone = Vec::new();
     let mut field_decls = Vec::new();
     let mut init = Vec::new();
 
@@ -425,20 +727,18 @@ fn build_iter_impl(
         cx,
         &mut step_forward,
         &mut step_backward,
-        field_specs,
-        &type_name,
+        fields,
+        &assoc_type,
         Some(cx.lt),
     )?;
 
-    for FieldSpec { name, kind, .. } in field_specs {
-        iter_clone.push(quote!(#name: #clone_t::clone(&self.#name)));
-
+    for Field { name, kind, .. } in fields {
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 field_decls.push(quote!(#name: #option<&#lt V>));
                 init.push(quote!(#name: #option::as_ref(&self.#name)));
             }
-            FieldKind::Complex { as_storage, .. } => {
+            Kind::Complex(Complex { as_storage, .. }) => {
                 field_decls.push(quote!(#name: #as_storage::Iter<#lt>));
                 init.push(quote!(#name: #as_storage::iter(&self.#name)));
             }
@@ -451,8 +751,9 @@ fn build_iter_impl(
         .push(cx.fallible(|| syn::parse2(quote!(V: #lt)))?);
 
     let double_ended_where_clause = &step_backward.where_clause;
+    let names = fields.names();
 
-    let iter_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct #type_name<#lt, V> where V: #lt {
             start: usize,
             end: usize,
@@ -466,7 +767,7 @@ fn build_iter_impl(
                 Self {
                     start: self.start,
                     end: self.end,
-                    #(#iter_clone,)*
+                    #(#names: #clone_t::clone(&self.#names),)*
                 }
             }
         }
@@ -490,18 +791,31 @@ fn build_iter_impl(
                 #option::None
             }
         }
-    };
+    });
 
-    Ok((iter_impl, init))
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type<#lt> = #type_name<#lt, V> where V: #lt;
+
+        #[inline]
+        fn iter(&self) -> Self::#assoc_type<'_> {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
 }
 
-/// Constructs a key's `iterator_t` implementation.
-fn build_keys_impl(
+/// Constructs a key's `Iterator` implementation.
+fn map_storage_keys(
     cx: &Ctxt<'_>,
-    id: &str,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, Vec<TokenStream>), ()> {
-    let type_name = syn::Ident::new(id, Span::call_site());
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{MAP_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
 
     let lt = cx.lt;
     let ident = &cx.ast.ident;
@@ -517,23 +831,20 @@ fn build_keys_impl(
     let mut step_forward = IteratorNext::default();
     let mut step_backward = IteratorNextBack::default();
 
-    let mut iter_clone = Vec::new();
     let mut field_decls = Vec::new();
     let mut init = Vec::new();
 
-    for FieldSpec {
+    for Field {
         span,
         index,
         name,
         var,
         kind,
         ..
-    } in field_specs
+    } in fields
     {
-        iter_clone.push(quote!(#name: #clone_t::clone(&self.#name)));
-
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 field_decls.push(quote!(#name: #bool_type));
                 init.push(quote!(#name: #option::is_some(&self.#name)));
 
@@ -553,8 +864,8 @@ fn build_keys_impl(
                     }
                 });
             }
-            FieldKind::Complex { as_storage, .. } => {
-                field_decls.push(quote!(#name: #as_storage::Keys<#lt>));
+            Kind::Complex(Complex { as_storage, .. }) => {
+                field_decls.push(quote!(#name: #as_storage::#assoc_type<#lt>));
                 init.push(quote!(#name: #as_storage::keys(&self.#name)));
 
                 step_forward.next.push(quote! {
@@ -575,7 +886,7 @@ fn build_keys_impl(
 
                 let where_clause = step_backward.make_where_clause();
 
-                let assoc_type = quote!(#as_storage::#type_name<#lt>);
+                let assoc_type = quote!(#as_storage::#assoc_type<#lt>);
 
                 where_clause.predicates.push(cx.fallible(|| syn::parse2(quote_spanned! {
                     *span => #assoc_type: #double_ended_iterator_t<Item = <#assoc_type as #iterator_t>::Item>
@@ -590,8 +901,9 @@ fn build_keys_impl(
         .push(cx.fallible(|| syn::parse2(quote!(V: #lt)))?);
 
     let double_ended_where_clause = &step_backward.where_clause;
+    let names = fields.names();
 
-    let iter_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct #type_name<#lt, V> where V: #lt {
             start: usize,
             end: usize,
@@ -605,7 +917,7 @@ fn build_keys_impl(
                 Self {
                     start: self.start,
                     end: self.end,
-                    #(#iter_clone,)*
+                    #(#names: #clone_t::clone(&self.#names),)*
                 }
             }
         }
@@ -629,18 +941,31 @@ fn build_keys_impl(
                 #option::None
             }
         }
-    };
+    });
 
-    Ok((iter_impl, init))
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type<#lt> = #type_name<#lt, V> where V: #lt;
+
+        #[inline]
+        fn keys(&self) -> Self::#assoc_type<'_> {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
 }
 
-/// Construct a values `iterator_t` implementation.
-fn build_values_impl(
+/// Construct a values `Iterator` implementation.
+fn map_storage_values(
     cx: &Ctxt<'_>,
-    id: &str,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, Vec<TokenStream>), ()> {
-    let type_name = syn::Ident::new(id, Span::call_site());
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{MAP_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
 
     let lt = cx.lt;
     let vis = &cx.ast.vis;
@@ -653,22 +978,19 @@ fn build_values_impl(
     let mut step_forward = IteratorNext::default();
     let mut step_backward = IteratorNextBack::default();
 
-    let mut iter_clone = Vec::new();
     let mut field_decls = Vec::new();
     let mut init = Vec::new();
 
-    for FieldSpec {
+    for Field {
         span,
         index,
         name,
         kind,
         ..
-    } in field_specs
+    } in fields
     {
-        iter_clone.push(quote!(#name: #clone_t::clone(&self.#name)));
-
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 field_decls.push(quote!(#name: #option<&#lt V>));
                 init.push(quote!(#name: #option::as_ref(&self.#name)));
 
@@ -688,8 +1010,8 @@ fn build_values_impl(
                     }
                 });
             }
-            FieldKind::Complex { as_storage, .. } => {
-                field_decls.push(quote!(#name: #as_storage::Values<#lt>));
+            Kind::Complex(Complex { as_storage, .. }) => {
+                field_decls.push(quote!(#name: #as_storage::#assoc_type<#lt>));
                 init.push(quote!(#name: #as_storage::values(&self.#name)));
 
                 step_forward.next.push(quote! {
@@ -710,7 +1032,7 @@ fn build_values_impl(
 
                 let where_clause = step_backward.make_where_clause();
 
-                let assoc_type = quote!(#as_storage::#type_name<#lt>);
+                let assoc_type = quote!(#as_storage::#assoc_type<#lt>);
 
                 where_clause.predicates.push(cx.fallible(|| syn::parse2(quote_spanned! {
                     *span => #assoc_type: #double_ended_iterator_t<Item = <#assoc_type as #iterator_t>::Item>
@@ -725,8 +1047,9 @@ fn build_values_impl(
         .push(cx.fallible(|| syn::parse2(quote!(V: #lt)))?);
 
     let double_ended_where_clause = &step_backward.where_clause;
+    let names = fields.names();
 
-    let iter_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct #type_name<#lt, V> where V: #lt {
             start: usize,
             end: usize,
@@ -740,7 +1063,7 @@ fn build_values_impl(
                 Self {
                     start: self.start,
                     end: self.end,
-                    #(#iter_clone,)*
+                    #(#names: #clone_t::clone(&self.#names),)*
                 }
             }
         }
@@ -764,18 +1087,31 @@ fn build_values_impl(
                 #option::None
             }
         }
-    };
+    });
 
-    Ok((iter_impl, init))
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type<#lt> = #type_name<#lt, V> where V: #lt;
+
+        #[inline]
+        fn values(&self) -> Self::#assoc_type<'_> {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
 }
 
 /// Construct an iterator implementation.
-fn build_iter_mut_impl(
+fn map_storage_iter_mut(
     cx: &Ctxt<'_>,
-    id: &str,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, Vec<TokenStream>), ()> {
-    let type_name = syn::Ident::new(id, Span::call_site());
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{MAP_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
 
     let ident = &cx.ast.ident;
     let lt = cx.lt;
@@ -795,23 +1131,23 @@ fn build_iter_mut_impl(
         cx,
         &mut step_forward,
         &mut step_backward,
-        field_specs,
-        &type_name,
+        fields,
+        &assoc_type,
         Some(cx.lt),
     )?;
 
-    for FieldSpec { name, kind, .. } in field_specs {
+    for Field { name, kind, .. } in fields {
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 field_decls.push(quote!(#name: #option<&#lt mut V>));
                 init.push(quote!(#name: #option::as_mut(&mut self.#name)));
             }
-            FieldKind::Complex {
+            Kind::Complex(Complex {
                 as_storage,
                 storage,
                 ..
-            } => {
-                field_decls.push(quote!(#name: #as_storage::IterMut<#lt>));
+            }) => {
+                field_decls.push(quote!(#name: #as_storage::#assoc_type<#lt>));
                 init.push(quote!(#name: #storage::iter_mut(&mut self.#name)));
             }
         }
@@ -824,7 +1160,7 @@ fn build_iter_mut_impl(
 
     let double_ended_where = &step_backward.where_clause;
 
-    let iter_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct #type_name<#lt, V> where V: #lt {
             start: usize,
             end: usize,
@@ -850,46 +1186,55 @@ fn build_iter_mut_impl(
                 #option::None
             }
         }
-    };
+    });
 
-    Ok((iter_impl, init))
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type<#lt> = #type_name<#lt, V> where V: #lt;
+
+        #[inline]
+        fn iter_mut(&mut self) -> Self::#assoc_type<'_> {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
 }
 
-/// Construct a values mutable `iterator_t` implementation.
-fn build_values_mut_impl(
+/// Construct a values mutable `Iterator` implementation.
+fn map_storage_values_mut(
     cx: &Ctxt<'_>,
-    id: &str,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, Vec<TokenStream>), ()> {
-    let type_name = syn::Ident::new(id, Span::call_site());
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{MAP_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
 
     let lt = cx.lt;
     let vis = &cx.ast.vis;
 
     let option = cx.toks.option();
     let iterator_t = cx.toks.iterator_t();
-    let clone_t = cx.toks.clone_t();
     let double_ended_iterator_t = cx.toks.double_ended_iterator_t();
 
     let mut step_forward = IteratorNext::default();
     let mut step_backward = IteratorNextBack::default();
 
-    let mut iter_clone = Vec::new();
     let mut field_decls = Vec::new();
     let mut init = Vec::new();
 
-    for FieldSpec {
+    for Field {
         span,
         index,
         name,
         kind,
         ..
-    } in field_specs
+    } in fields
     {
-        iter_clone.push(quote!(#name: #clone_t::clone(&self.#name)));
-
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 field_decls.push(quote!(#name: #option<&#lt mut V>));
                 init.push(quote!(#name: #option::as_mut(&mut self.#name)));
 
@@ -909,8 +1254,8 @@ fn build_values_mut_impl(
                     }
                 });
             }
-            FieldKind::Complex { as_storage, .. } => {
-                field_decls.push(quote!(#name: #as_storage::ValuesMut<#lt>));
+            Kind::Complex(Complex { as_storage, .. }) => {
+                field_decls.push(quote!(#name: #as_storage::#assoc_type<#lt>));
                 init.push(quote!(#name: #as_storage::values_mut(&mut self.#name)));
 
                 step_forward.next.push(quote! {
@@ -931,7 +1276,7 @@ fn build_values_mut_impl(
 
                 let where_clause = step_backward.make_where_clause();
 
-                let assoc_type = quote!(#as_storage::#type_name<#lt>);
+                let assoc_type = quote!(#as_storage::#assoc_type<#lt>);
 
                 where_clause.predicates.push(cx.fallible(|| syn::parse2(quote_spanned! {
                     *span => #assoc_type: #double_ended_iterator_t<Item = <#assoc_type as #iterator_t>::Item>
@@ -947,7 +1292,7 @@ fn build_values_mut_impl(
 
     let double_ended_where_clause = &step_backward.where_clause;
 
-    let iter_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct #type_name<#lt, V> where V: #lt {
             start: usize,
             end: usize,
@@ -973,18 +1318,31 @@ fn build_values_mut_impl(
                 #option::None
             }
         }
-    };
+    });
 
-    Ok((iter_impl, init))
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type<#lt> = #type_name<#lt, V> where V: #lt;
+
+        #[inline]
+        fn values_mut(&mut self) -> Self::#assoc_type<'_> {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
 }
 
 /// Construct `IntoIter` implementation.
-fn build_into_iter_impl(
+fn map_storage_into_iter(
     cx: &Ctxt<'_>,
-    id: &str,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, Vec<TokenStream>), ()> {
-    let type_name = syn::Ident::new(id, Span::call_site());
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{MAP_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
 
     let ident = &cx.ast.ident;
     let vis = &cx.ast.vis;
@@ -999,41 +1357,40 @@ fn build_into_iter_impl(
 
     let mut field_decls = Vec::new();
     let mut init = Vec::new();
-    let mut field_clone = Vec::new();
-    let mut clone_bounds = Vec::new();
 
     build_iter_next(
         cx,
         &mut step_forward,
         &mut step_backward,
-        field_specs,
-        &type_name,
+        fields,
+        &assoc_type,
         None,
     )?;
 
-    for FieldSpec { name, kind, .. } in field_specs {
-        field_clone.push(quote!(#name: #clone_t::clone(&self.#name)));
-
+    for Field { name, kind, .. } in fields {
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 field_decls.push(quote!(#name: #option<V>));
                 init.push(quote!(#name: self.#name));
             }
-            FieldKind::Complex {
+            Kind::Complex(Complex {
                 as_storage,
                 storage,
                 ..
-            } => {
-                field_decls.push(quote!(#name: #as_storage::IntoIter));
+            }) => {
+                field_decls.push(quote!(#name: #as_storage::#assoc_type));
                 init.push(quote!(#name: #storage::into_iter(self.#name)));
-                clone_bounds.push(quote!(#as_storage::IntoIter: #clone_t));
             }
         }
     }
 
     let double_ended_where = &step_backward.where_clause;
+    let names = fields.names();
+    let clone_bounds = fields
+        .complex()
+        .map(|Complex { as_storage, .. }| quote!(#as_storage::#assoc_type: #clone_t));
 
-    let iter_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct #type_name<V> {
             start: usize,
             end: usize,
@@ -1047,7 +1404,7 @@ fn build_into_iter_impl(
                 Self {
                     start: self.start,
                     end: self.end,
-                    #(#field_clone,)*
+                    #(#names: #clone_t::clone(&self.#names),)*
                 }
             }
         }
@@ -1071,9 +1428,322 @@ fn build_into_iter_impl(
                 #option::None
             }
         }
-    };
+    });
 
-    Ok((iter_impl, init))
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type = #type_name<V>;
+
+        #[inline]
+        fn into_iter(self) -> Self::#assoc_type {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
+}
+
+/// Constructs a sets iterator implementation.
+fn set_storage_iter(
+    cx: &Ctxt<'_>,
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{SET_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
+
+    let lt = cx.lt;
+    let ident = &cx.ast.ident;
+    let vis = &cx.ast.vis;
+
+    let bool_type = cx.toks.bool_type();
+    let clone_t = cx.toks.clone_t();
+    let double_ended_iterator_t = cx.toks.double_ended_iterator_t();
+    let iterator_t = cx.toks.iterator_t();
+    let mem = cx.toks.mem();
+    let option = cx.toks.option();
+
+    let mut step_forward = IteratorNext::default();
+    let mut step_backward = IteratorNextBack::default();
+
+    let mut field_decls = Vec::new();
+    let mut init = Vec::new();
+
+    for Field {
+        span,
+        index,
+        name,
+        var,
+        kind,
+        ..
+    } in fields
+    {
+        match kind {
+            Kind::Simple => {
+                field_decls.push(quote!(#name: #bool_type));
+                init.push(quote!(#name: self.#name));
+
+                step_forward.next.push(quote! {
+                    #index => {
+                        if #mem::take(&mut self.#name) {
+                            return #option::Some(#ident::#var);
+                        }
+                    }
+                });
+
+                step_backward.next.push(quote! {
+                    #index => {
+                        if #mem::take(&mut self.#name) {
+                            return #option::Some(#ident::#var);
+                        }
+                    }
+                });
+            }
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                field_decls.push(quote!(#name: #as_set_storage::#assoc_type<#lt>));
+                init.push(quote!(#name: #as_set_storage::iter(&self.#name)));
+
+                step_forward.next.push(quote! {
+                    #index => {
+                        if let #option::Some(key) = #iterator_t::next(&mut self.#name) {
+                            return #option::Some(#ident::#var(key));
+                        }
+                    }
+                });
+
+                step_backward.next.push(quote! {
+                    #index => {
+                        if let #option::Some(key) = #double_ended_iterator_t::next_back(&mut self.#name) {
+                            return #option::Some(#ident::#var(key));
+                        }
+                    }
+                });
+
+                let where_clause = step_backward.make_where_clause();
+
+                let assoc_type = quote!(#as_set_storage::#assoc_type<#lt>);
+
+                where_clause.predicates.push(cx.fallible(|| syn::parse2(quote_spanned! {
+                    *span => #assoc_type: #double_ended_iterator_t<Item = <#assoc_type as #iterator_t>::Item>
+                }))?);
+            }
+        }
+    }
+
+    let double_ended_where_clause = &step_backward.where_clause;
+    let names = fields.names();
+
+    output.impls.extend(quote! {
+        #vis struct #type_name<#lt> {
+            start: usize,
+            end: usize,
+            #(#field_decls,)*
+        }
+
+        #[automatically_derived]
+        impl<#lt> #clone_t for #type_name<#lt> {
+            #[inline]
+            fn clone(&self) -> Self {
+                Self {
+                    start: self.start,
+                    end: self.end,
+                    #(#names: #clone_t::clone(&self.#names),)*
+                }
+            }
+        }
+
+        #[automatically_derived]
+        impl<#lt> #iterator_t for #type_name<#lt> {
+            type Item = #ident;
+
+            #[inline]
+            fn next(&mut self) -> #option<Self::Item> {
+                #step_forward
+                #option::None
+            }
+        }
+
+        #[automatically_derived]
+        impl<#lt> #double_ended_iterator_t for #type_name<#lt> #double_ended_where_clause {
+            #[inline]
+            fn next_back(&mut self) -> #option<Self::Item> {
+                #step_backward
+                #option::None
+            }
+        }
+    });
+
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type<#lt> = #type_name<#lt>;
+
+        #[inline]
+        fn iter(&self) -> Self::#assoc_type<'_> {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
+}
+
+/// Constructs a sets owning iterator implementation.
+fn set_storage_into_iter(
+    cx: &Ctxt<'_>,
+    assoc_type: &str,
+    fields: &Fields<'_>,
+    output: &mut Output,
+) -> Result<(), ()> {
+    let type_name = format_ident!("{SET_STORAGE}{assoc_type}");
+    let assoc_type = Ident::new(assoc_type, Span::call_site());
+
+    let ident = &cx.ast.ident;
+    let vis = &cx.ast.vis;
+
+    let bool_type = cx.toks.bool_type();
+    let clone_t = cx.toks.clone_t();
+    let double_ended_iterator_t = cx.toks.double_ended_iterator_t();
+    let iterator_t = cx.toks.iterator_t();
+    let mem = cx.toks.mem();
+    let option = cx.toks.option();
+
+    let mut step_forward = IteratorNext::default();
+    let mut step_backward = IteratorNextBack::default();
+
+    let mut field_decls = Vec::new();
+    let mut init = Vec::new();
+
+    for Field {
+        span,
+        index,
+        name,
+        var,
+        kind,
+        ..
+    } in fields
+    {
+        match kind {
+            Kind::Simple => {
+                field_decls.push(quote!(#name: #bool_type));
+                init.push(quote!(#name: self.#name));
+
+                step_forward.next.push(quote! {
+                    #index => {
+                        if #mem::take(&mut self.#name) {
+                            return #option::Some(#ident::#var);
+                        }
+                    }
+                });
+
+                step_backward.next.push(quote! {
+                    #index => {
+                        if #mem::take(&mut self.#name) {
+                            return #option::Some(#ident::#var);
+                        }
+                    }
+                });
+            }
+            Kind::Complex(Complex { as_set_storage, .. }) => {
+                field_decls.push(quote!(#name: #as_set_storage::#assoc_type));
+                init.push(quote!(#name: #as_set_storage::into_iter(self.#name)));
+
+                step_forward.next.push(quote! {
+                    #index => {
+                        if let #option::Some(key) = #iterator_t::next(&mut self.#name) {
+                            return #option::Some(#ident::#var(key));
+                        }
+                    }
+                });
+
+                step_backward.next.push(quote! {
+                    #index => {
+                        if let #option::Some(key) = #double_ended_iterator_t::next_back(&mut self.#name) {
+                            return #option::Some(#ident::#var(key));
+                        }
+                    }
+                });
+
+                let where_clause = step_backward.make_where_clause();
+
+                let assoc_type = quote!(#as_set_storage::#assoc_type);
+
+                where_clause.predicates.push(cx.fallible(|| syn::parse2(quote_spanned! {
+                    *span => for<'trivial_bounds> #assoc_type: #double_ended_iterator_t<Item = <#assoc_type as #iterator_t>::Item>
+                }))?);
+            }
+        }
+    }
+
+    let names = fields.names();
+
+    output.impls.extend(quote! {
+        #vis struct #type_name {
+            start: usize,
+            end: usize,
+            #(#field_decls,)*
+        }
+    });
+
+    {
+        let bounds = fields
+            .complex()
+            .map(|Complex { as_set_storage, .. }| quote!(#as_set_storage::#assoc_type));
+
+        output.impls.extend(quote! {
+            #[automatically_derived]
+            impl #clone_t for #type_name where #(for<'trivial_bounds> #bounds: #clone_t,)* {
+                #[inline]
+                fn clone(&self) -> Self {
+                    Self {
+                        start: self.start,
+                        end: self.end,
+                        #(#names: #clone_t::clone(&self.#names),)*
+                    }
+                }
+            }
+        });
+    }
+
+    output.impls.extend(quote! {
+        #[automatically_derived]
+        impl #iterator_t for #type_name {
+            type Item = #ident;
+
+            #[inline]
+            fn next(&mut self) -> #option<Self::Item> {
+                #step_forward
+                #option::None
+            }
+        }
+    });
+
+    let double_ended_where_clause = &step_backward.where_clause;
+
+    output.impls.extend(quote! {
+        #[automatically_derived]
+        impl #double_ended_iterator_t for #type_name #double_ended_where_clause {
+            #[inline]
+            fn next_back(&mut self) -> #option<Self::Item> {
+                #step_backward
+                #option::None
+            }
+        }
+    });
+
+    let end = fields.len();
+
+    output.items.extend(quote! {
+        type #assoc_type = #type_name;
+
+        #[inline]
+        fn into_iter(self) -> Self::#assoc_type {
+            #type_name { start: 0, end: #end, #(#init,)* }
+        }
+    });
+
+    Ok(())
 }
 
 #[derive(Default)]
@@ -1134,10 +1804,12 @@ impl ToTokens for IteratorNextBack {
 }
 
 /// Construct `StorageEntry` implementation.
-fn build_entry_impl(
+fn map_storage_entry(
     cx: &Ctxt<'_>,
-    field_specs: &[FieldSpec<'_>],
-) -> Result<(TokenStream, TokenStream), ()> {
+    fields: &Fields<'_>,
+    storage: &Ident,
+    output: &mut Output,
+) -> Result<(), ()> {
     let ident = &cx.ast.ident;
     let vis = &cx.ast.vis;
     let lt = cx.lt;
@@ -1165,19 +1837,19 @@ fn build_entry_impl(
     let mut occupied_insert = Vec::new();
     let mut occupied_remove = Vec::new();
 
-    for FieldSpec {
+    for Field {
         name, kind, var, ..
-    } in field_specs
+    } in fields
     {
         let pattern = quote!(#ident::#var);
 
         match kind {
-            FieldKind::Simple => {
+            Kind::Simple => {
                 init.push(quote!( #pattern => option_to_entry(&mut self.#name, key) ));
             }
-            FieldKind::Complex {
+            Kind::Complex(Complex {
                 element, storage, ..
-            } => {
+            }) => {
                 let as_storage = quote!(<#storage as #storage_t<#element, V>>);
 
                 occupied_variant.push(quote!( #name(#as_storage::Occupied<#lt>) ));
@@ -1220,7 +1892,7 @@ fn build_entry_impl(
         }
     }
 
-    let entry_impl = quote! {
+    output.impls.extend(quote! {
         #vis struct SimpleVacantEntry<#lt, V> {
             key: #ident,
             inner: #option_bucket_none<#lt, V>,
@@ -1346,15 +2018,15 @@ fn build_entry_impl(
         }
 
         #[inline]
-        fn option_to_entry<V>(opt: &mut #option<V>, key: #ident) -> #entry_enum<'_, Storage<V>, #ident, V> {
+        fn option_to_entry<V>(opt: &mut #option<V>, key: #ident) -> #entry_enum<'_, #storage<V>, #ident, V> {
             match #option_bucket_option::new(opt) {
                 #option_bucket_option::Some(inner) => #entry_enum::Occupied(OccupiedEntry::Simple(SimpleOccupiedEntry { key, inner })),
                 #option_bucket_option::None(inner) => #entry_enum::Vacant(VacantEntry::Simple(SimpleVacantEntry { key, inner })),
             }
         }
-    };
+    });
 
-    let entry_storage_impl = quote! {
+    output.items.extend(quote! {
         type Occupied<#lt> = OccupiedEntry<#lt, V> where V: #lt;
         type Vacant<#lt> = VacantEntry<#lt, V> where V: #lt;
 
@@ -1364,7 +2036,86 @@ fn build_entry_impl(
                 #(#init,)*
             }
         }
-    };
+    });
 
-    Ok((entry_impl, entry_storage_impl))
+    Ok(())
+}
+
+/// Output collector.
+#[derive(Default)]
+struct Output {
+    impls: TokenStream,
+    items: TokenStream,
+}
+
+/// A field specification.
+pub(crate) struct Field<'a> {
+    pub(crate) span: Span,
+    pub(crate) index: usize,
+    /// Index-based name (`f1`, `f2`)
+    pub(crate) name: Ident,
+    /// Variant name
+    pub(crate) var: &'a Ident,
+    pub(crate) kind: Kind<'a>,
+}
+
+/// The kind of a single storage element.
+pub(crate) enum Kind<'a> {
+    Simple,
+    Complex(Complex<'a>),
+}
+
+/// A complex field kind.
+pub(crate) struct Complex<'a> {
+    /// Type of variant field
+    pub(crate) element: &'a syn::Field,
+    /// <E as Key>::Storage::<V> (E = type of variant field)
+    pub(crate) storage: TokenStream,
+    /// <<E as Key>::Storage::<V> as Storage<E, V>> (E = type of variant field)
+    pub(crate) as_storage: TokenStream,
+    /// <E as Key>::SetStorage (E = type of variant field)
+    pub(crate) set_storage: TokenStream,
+    /// <<E as Key>::SetStorage as SetStorage<E>> (E = type of variant field)
+    pub(crate) as_set_storage: TokenStream,
+}
+
+#[derive(Default)]
+pub(crate) struct Fields<'a> {
+    fields: Vec<Field<'a>>,
+    patterns: Vec<Pat>,
+}
+
+impl<'a> Fields<'a> {
+    /// Get names of all the fields.
+    fn names(&self) -> impl Iterator<Item = &'_ Ident> {
+        self.fields.iter().map(|f| &f.name)
+    }
+
+    /// Get names of all the fields.
+    fn complex(&self) -> impl Iterator<Item = &'_ Complex<'a>> {
+        self.fields.iter().filter_map(|f| match &f.kind {
+            Kind::Complex(c) => Some(c),
+            Kind::Simple => None,
+        })
+    }
+
+    /// Iterate over fields.
+    fn iter(&self) -> ::core::slice::Iter<'_, Field<'a>> {
+        self.fields.iter()
+    }
+
+    /// Length of fields.
+    fn len(&self) -> usize {
+        self.fields.len()
+    }
+}
+
+impl<'b, 'a> IntoIterator for &'b Fields<'a> {
+    type Item = &'b Field<'a>;
+    type IntoIter = ::core::slice::Iter<'b, Field<'a>>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.iter()
+    }
 }

--- a/fixed-map-derive/src/context.rs
+++ b/fixed-map-derive/src/context.rs
@@ -80,7 +80,7 @@ toks! {
         partial_ord_t = [::core::cmp::PartialOrd],
         slice_iter = [::core::slice::Iter],
         slice_iter_mut = [::core::slice::IterMut],
-        storage_t = [crate::map::Storage],
+        map_storage_t = [crate::map::MapStorage],
         set_storage_t = [crate::set::SetStorage],
         vacant_entry_t = [crate::map::VacantEntry],
     }

--- a/fixed-map-derive/src/context.rs
+++ b/fixed-map-derive/src/context.rs
@@ -1,7 +1,7 @@
 use core::cell::RefCell;
 use core::fmt;
 
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::Span;
 use syn::{DeriveInput, Path};
 
 // Builder function to use when constructing token.
@@ -61,9 +61,11 @@ toks! {
         hasher_t = [::core::hash::Hasher],
         into_iterator_t = [::core::iter::IntoIterator],
         iterator_cmp = [crate::macro_support::__storage_iterator_cmp],
+        iterator_cmp_bool = [crate::macro_support::__storage_iterator_cmp_bool],
         iterator_flat_map = [::core::iter::FlatMap],
         iterator_flatten = [::core::iter::Flatten],
         iterator_partial_cmp = [crate::macro_support::__storage_iterator_partial_cmp],
+        iterator_partial_cmp_bool = [crate::macro_support::__storage_iterator_partial_cmp_bool],
         iterator_t = [::core::iter::Iterator],
         key_t = [crate::key::Key],
         mem = [::core::mem],
@@ -79,6 +81,7 @@ toks! {
         slice_iter = [::core::slice::Iter],
         slice_iter_mut = [::core::slice::IterMut],
         storage_t = [crate::map::Storage],
+        set_storage_t = [crate::set::SetStorage],
         vacant_entry_t = [crate::map::VacantEntry],
     }
 }
@@ -156,28 +159,4 @@ impl<'a> Ctxt<'a> {
             }
         }
     }
-}
-
-/// A field specification.
-pub(crate) struct FieldSpec<'a> {
-    pub(crate) span: Span,
-    pub(crate) index: usize,
-    /// Index-based name (`f1`, `f2`)
-    pub(crate) name: syn::Ident,
-    /// Variant name
-    pub(crate) var: &'a syn::Ident,
-    pub(crate) kind: FieldKind,
-}
-
-/// The kind of a field.
-pub(crate) enum FieldKind {
-    Simple,
-    Complex {
-        /// Type of variant field
-        element: TokenStream,
-        /// <E as Key>::Storage::<V> (E = type of variant field)
-        storage: TokenStream,
-        /// <<E as Key>::Storage::<V> as Storage<E, V>> (E = type of variant field)
-        as_storage: TokenStream,
-    },
 }

--- a/fixed-map-derive/src/unit_variants.rs
+++ b/fixed-map-derive/src/unit_variants.rs
@@ -14,14 +14,16 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
     let clone_t = cx.toks.clone_t();
     let copy_t = cx.toks.copy_t();
     let entry_enum = cx.toks.entry_enum();
-    let eq = cx.toks.eq_t();
-    let hash = cx.toks.hash_t();
+    let eq_t = cx.toks.eq_t();
+    let hash_t = cx.toks.hash_t();
     let hasher = cx.toks.hasher_t();
     let into_iterator_t = cx.toks.into_iterator_t();
     let iterator_cmp = cx.toks.iterator_cmp();
+    let iterator_cmp_bool = cx.toks.iterator_cmp_bool();
     let iterator_flat_map = cx.toks.iterator_flat_map();
     let iterator_flatten = cx.toks.iterator_flatten();
     let iterator_partial_cmp = cx.toks.iterator_partial_cmp();
+    let iterator_partial_cmp_bool = cx.toks.iterator_partial_cmp_bool();
     let iterator_t = cx.toks.iterator_t();
     let key_t = cx.toks.key_t();
     let mem = cx.toks.mem();
@@ -37,6 +39,7 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
     let slice_iter = cx.toks.slice_iter();
     let slice_iter_mut = cx.toks.slice_iter_mut();
     let storage_t = cx.toks.storage_t();
+    let set_storage_t = cx.toks.set_storage_t();
     let vacant_entry_t = cx.toks.vacant_entry_t();
 
     let const_wrapper = Ident::new(
@@ -48,12 +51,16 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
     let mut variants = Vec::with_capacity(count);
     let mut names = Vec::with_capacity(count);
     let mut field_inits = Vec::with_capacity(count);
+    let mut set_inits = Vec::with_capacity(count);
 
     for (index, variant) in en.variants.iter().enumerate() {
         field_inits.push(quote!(#option::None));
+        set_inits.push(quote!(false));
         variants.push(&variant.ident);
         names.push(format_ident!("_{}", index));
     }
+
+    let storage = format_ident!("Storage");
 
     let entry_impl = quote! {
         #vis struct VacantEntry<#lt, V> {
@@ -113,7 +120,7 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
         }
 
         #[inline]
-        fn option_to_entry<V>(opt: &mut #option<V>, key: #ident) -> #entry_enum<'_, Storage<V>, #ident, V> {
+        fn option_to_entry<V>(opt: &mut #option<V>, key: #ident) -> #entry_enum<'_, #storage<V>, #ident, V> {
             match #option_bucket_option::new(opt) {
                 #option_bucket_option::Some(inner) => #entry_enum::Occupied(OccupiedEntry { key, inner }),
                 #option_bucket_option::None(inner) => #entry_enum::Vacant(VacantEntry { key, inner }),
@@ -121,218 +128,329 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
         }
     };
 
+    let storage_impl = quote! {
+        #[repr(transparent)]
+        #vis struct #storage<V> {
+            data: [#option<V>; #count],
+        }
+
+        #[automatically_derived]
+        impl<V> #clone_t for #storage<V> where V: #clone_t {
+            #[inline]
+            fn clone(&self) -> Self {
+                Self {
+                    data: #clone_t::clone(&self.data),
+                }
+            }
+        }
+
+        #[automatically_derived]
+        impl<V> #copy_t for #storage<V> where V: #copy_t {
+        }
+
+        #[automatically_derived]
+        impl<V> #partial_eq_t for #storage<V> where V: #partial_eq_t {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                #partial_eq_t::eq(&self.data, &other.data)
+            }
+        }
+
+        #[automatically_derived]
+        impl<V> #eq_t for #storage<V> where V: #eq_t {}
+
+        #[automatically_derived]
+        impl<V> #hash_t for #storage<V> where V: #hash_t {
+            #[inline]
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: #hasher,
+            {
+                #hash_t::hash(&self.data, state);
+            }
+        }
+
+        #[automatically_derived]
+        impl<V> #partial_ord_t for #storage<V> where V: #partial_ord_t {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<#ordering> {
+                #iterator_partial_cmp(&self.data, &other.data)
+            }
+        }
+
+        #[automatically_derived]
+        impl<V> #ord_t for #storage<V> where V: #ord_t {
+            #[inline]
+            fn cmp(&self, other: &Self) -> #ordering {
+                #iterator_cmp(&self.data, &other.data)
+            }
+        }
+
+        #[automatically_derived]
+        impl<V> #storage_t<#ident, V> for #storage<V> {
+            type Iter<#lt> = #iterator_flat_map<
+                #array_into_iter<(#ident, &#lt #option<V>), #count>,
+                #option<(#ident, &#lt V)>,
+                fn((#ident, &#lt #option<V>)) -> #option<(#ident, &#lt V)>
+            > where V: #lt;
+            type Keys<#lt> = #iterator_flatten<#array_into_iter<#option<#ident>, #count>> where V: #lt;
+            type Values<#lt> = #iterator_flatten<#slice_iter<#lt, #option<V>>> where V: #lt;
+            type IterMut<#lt> = #iterator_flat_map<
+                #array_into_iter<(#ident, &#lt mut #option<V>), #count>,
+                #option<(#ident, &#lt mut V)>,
+                fn((#ident, &#lt mut #option<V>)) -> #option<(#ident, &#lt mut V)>
+            > where V: #lt;
+            type ValuesMut<#lt> = #iterator_flatten<#slice_iter_mut<#lt, #option<V>>> where V: #lt;
+            type IntoIter = #iterator_flat_map<
+                #array_into_iter<(#ident, #option<V>), #count>,
+                #option<(#ident, V)>,
+                fn((#ident, #option<V>)) -> #option<(#ident, V)>
+            >;
+            type Occupied<#lt> = OccupiedEntry<#lt, V> where V: #lt;
+            type Vacant<#lt> = VacantEntry<#lt, V> where V: #lt;
+
+            #[inline]
+            fn empty() -> Self {
+                Self {
+                    data: [#(#field_inits),*],
+                }
+            }
+
+            #[inline]
+            fn len(&self) -> usize {
+                let [#(#names),*] = &self.data;
+                0 #(+ usize::from(#option::is_some(#names)))*
+            }
+
+            #[inline]
+            fn is_empty(&self) -> bool {
+                let [#(#names),*] = &self.data;
+                true #(&& #option::is_none(#names))*
+            }
+
+            #[inline]
+            fn insert(&mut self, key: #ident, value: V) -> #option<V> {
+                let [#(#names),*] = &mut self.data;
+
+                match key {
+                    #(#ident::#variants => #mem::replace(#names, #option::Some(value)),)*
+                }
+            }
+
+            #[inline]
+            fn contains_key(&self, value: #ident) -> bool {
+                let [#(#names),*] = &self.data;
+
+                match value {
+                    #(#ident::#variants => #option::is_some(#names),)*
+                }
+            }
+
+            #[inline]
+            fn get(&self, value: #ident) -> #option<&V> {
+                let [#(#names),*] = &self.data;
+
+                match value {
+                    #(#ident::#variants => #option::as_ref(#names),)*
+                }
+            }
+
+            #[inline]
+            fn get_mut(&mut self, value: #ident) -> #option<&mut V> {
+                let [#(#names),*] = &mut self.data;
+
+                match value {
+                    #(#ident::#variants => #option::as_mut(#names),)*
+                }
+            }
+
+            #[inline]
+            fn remove(&mut self, value: #ident) -> #option<V> {
+                let [#(#names),*] = &mut self.data;
+
+                match value {
+                    #(#ident::#variants => #mem::take(#names),)*
+                }
+            }
+
+            #[inline]
+            fn retain<F>(&mut self, mut func: F)
+            where
+                F: FnMut(#ident, &mut V) -> bool
+            {
+                let [#(#names),*] = &mut self.data;
+
+                #(if let #option::Some(val) = #option::as_mut(#names) {
+                    if !func(#ident::#variants, val) {
+                        *#names = None;
+                    }
+                })*
+            }
+
+            #[inline]
+            fn clear(&mut self) {
+                self.data = [#(#field_inits),*];
+            }
+
+            #[inline]
+            fn iter(&self) -> Self::Iter<'_> {
+                let [#(#names),*] = &self.data;
+                #iterator_t::flat_map(#into_iterator_t::into_iter([#((#ident::#variants, #names)),*]), |(k, v)| #option::Some((k, #option::as_ref(v)?)))
+            }
+
+            #[inline]
+            fn keys(&self) -> Self::Keys<'_> {
+                let [#(#names),*] = &self.data;
+                #iterator_t::flatten(#into_iterator_t::into_iter([#(if #names.is_some() { Some(#ident::#variants) } else { None }),*]))
+            }
+
+            #[inline]
+            fn values(&self) -> Self::Values<'_> {
+                #iterator_t::flatten(#into_iterator_t::into_iter(&self.data))
+            }
+
+            #[inline]
+            fn iter_mut(&mut self) -> Self::IterMut<'_> {
+                let [#(#names),*] = &mut self.data;
+                #iterator_t::flat_map(#into_iterator_t::into_iter([#((#ident::#variants, #names)),*]), |(k, v)| #option::Some((k, #option::as_mut(v)?)))
+            }
+
+            #[inline]
+            fn values_mut(&mut self) -> Self::ValuesMut<'_> {
+                #iterator_t::flatten(#into_iterator_t::into_iter(&mut self.data))
+            }
+
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                let [#(#names),*] = self.data;
+                #iterator_t::flat_map(#into_iterator_t::into_iter([#((#ident::#variants, #names)),*]), |(k, v)| #option::Some((k, v?)))
+            }
+
+            #[inline]
+            fn entry(&mut self, key: #ident) -> #entry_enum<'_, Self, #ident, V> {
+                let [#(#names),*] = &mut self.data;
+
+                match key {
+                    #(#ident::#variants => option_to_entry(#names, key),)*
+                }
+            }
+        }
+    };
+
+    let set_storage_impl = quote! {
+        #[repr(transparent)]
+        #[derive(#clone_t, #copy_t, #partial_eq_t, #eq_t, #hash_t)]
+        #vis struct SetStorage {
+            data: [bool; #count],
+        }
+
+        #[automatically_derived]
+        impl #partial_ord_t for SetStorage {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<#ordering> {
+                #iterator_partial_cmp_bool(&self.data, &other.data)
+            }
+        }
+
+        #[automatically_derived]
+        impl #ord_t for SetStorage {
+            #[inline]
+            fn cmp(&self, other: &Self) -> #ordering {
+                #iterator_cmp_bool(&self.data, &other.data)
+            }
+        }
+
+        #[automatically_derived]
+        impl #set_storage_t<#ident> for SetStorage {
+            type Iter<#lt> = #iterator_flatten<#array_into_iter<#option<#ident>, #count>>;
+            type IntoIter = #iterator_flatten<#array_into_iter<#option<#ident>, #count>>;
+
+            #[inline]
+            fn empty() -> Self {
+                Self {
+                    data: [#(#set_inits),*],
+                }
+            }
+
+            #[inline]
+            fn len(&self) -> usize {
+                let [#(#names),*] = &self.data;
+                0 #(+ usize::from(*#names))*
+            }
+
+            #[inline]
+            fn is_empty(&self) -> bool {
+                let [#(#names),*] = &self.data;
+                true #(&& !*#names)*
+            }
+
+            #[inline]
+            fn insert(&mut self, value: #ident) -> bool {
+                let [#(#names),*] = &mut self.data;
+
+                match value {
+                    #(#ident::#variants => !#mem::replace(#names, true),)*
+                }
+            }
+
+            #[inline]
+            fn contains(&self, value: #ident) -> bool {
+                let [#(#names),*] = &self.data;
+
+                match value {
+                    #(#ident::#variants => *#names,)*
+                }
+            }
+
+            #[inline]
+            fn remove(&mut self, value: #ident) -> bool {
+                let [#(#names),*] = &mut self.data;
+
+                match value {
+                    #(#ident::#variants => #mem::replace(#names, false),)*
+                }
+            }
+
+            #[inline]
+            fn retain<F>(&mut self, mut f: F)
+            where
+                F: FnMut(#ident) -> bool
+            {
+                let [#(#names),*] = &mut self.data;
+
+                #(if *#names {
+                    *#names = f(#ident::#variants);
+                })*
+            }
+
+            #[inline]
+            fn clear(&mut self) {
+                self.data = [#(#set_inits),*];
+            }
+
+            #[inline]
+            fn iter(&self) -> Self::Iter<'_> {
+                let [#(#names),*] = &self.data;
+                #iterator_t::flatten(#into_iterator_t::into_iter([#(if *#names { Some(#ident::#variants) } else { None }),*]))
+            }
+
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                let [#(#names),*] = &self.data;
+                #iterator_t::flatten(#into_iterator_t::into_iter([#(if *#names { Some(#ident::#variants) } else { None }),*]))
+            }
+        }
+    };
+
     Ok(quote! {
         const #const_wrapper: () = {
-            #[repr(transparent)]
-            #vis struct Storage<V> {
-                data: [#option<V>; #count],
-            }
-
-            #[automatically_derived]
-            impl<V> #clone_t for Storage<V> where V: #clone_t {
-                #[inline]
-                fn clone(&self) -> Storage<V> {
-                    Storage {
-                        data: #clone_t::clone(&self.data),
-                    }
-                }
-            }
-
-            #[automatically_derived]
-            impl<V> #copy_t for Storage<V> where V: #copy_t {
-            }
-
-            #[automatically_derived]
-            impl<V> #partial_eq_t for Storage<V> where V: #partial_eq_t {
-                #[inline]
-                fn eq(&self, other: &Storage<V>) -> bool {
-                    #partial_eq_t::eq(&self.data, &other.data)
-                }
-            }
-
-            #[automatically_derived]
-            impl<V> #eq for Storage<V> where V: #eq {}
-
-            #[automatically_derived]
-            impl<V> #hash for Storage<V> where V: #hash {
-                #[inline]
-                fn hash<H>(&self, state: &mut H)
-                where
-                    H: #hasher,
-                {
-                    #hash::hash(&self.data, state);
-                }
-            }
-
-            #[automatically_derived]
-            impl<V> #partial_ord_t for Storage<V> where V: #partial_ord_t {
-                #[inline]
-                fn partial_cmp(&self, other: &Self) -> Option<#ordering> {
-                    #iterator_partial_cmp(&self.data, &other.data)
-                }
-            }
-
-            #[automatically_derived]
-            impl<V> #ord_t for Storage<V> where V: #ord_t {
-                #[inline]
-                fn cmp(&self, other: &Self) -> #ordering {
-                    #iterator_cmp(&self.data, &other.data)
-                }
-            }
-
-            #[automatically_derived]
-            impl<V> #storage_t<#ident, V> for Storage<V> {
-                type Iter<#lt> = #iterator_flat_map<
-                    #array_into_iter<(#ident, &#lt #option<V>), #count>,
-                    #option<(#ident, &#lt V)>,
-                    fn((#ident, &#lt #option<V>)) -> #option<(#ident, &#lt V)>
-                > where V: #lt;
-                type Keys<#lt> = #iterator_flatten<#array_into_iter<#option<#ident>, #count>> where V: #lt;
-                type Values<#lt> = #iterator_flatten<#slice_iter<#lt, #option<V>>> where V: #lt;
-                type IterMut<#lt> = #iterator_flat_map<
-                    #array_into_iter<(#ident, &#lt mut #option<V>), #count>,
-                    #option<(#ident, &#lt mut V)>,
-                    fn((#ident, &#lt mut #option<V>)) -> #option<(#ident, &#lt mut V)>
-                > where V: #lt;
-                type ValuesMut<#lt> = #iterator_flatten<#slice_iter_mut<#lt, #option<V>>> where V: #lt;
-                type IntoIter = #iterator_flat_map<
-                    #array_into_iter<(#ident, #option<V>), #count>,
-                    #option<(#ident, V)>,
-                    fn((#ident, #option<V>)) -> #option<(#ident, V)>
-                >;
-                type Occupied<#lt> = OccupiedEntry<#lt, V> where V: #lt;
-                type Vacant<#lt> = VacantEntry<#lt, V> where V: #lt;
-
-                #[inline]
-                fn empty() -> Self {
-                    Self {
-                        data: [#(#field_inits),*],
-                    }
-                }
-
-                #[inline]
-                fn len(&self) -> usize {
-                    let [#(#names),*] = &self.data;
-                    0 #(+ usize::from(#option::is_some(#names)))*
-                }
-
-                #[inline]
-                fn is_empty(&self) -> bool {
-                    let [#(#names),*] = &self.data;
-                    true #(&& #option::is_none(#names))*
-                }
-
-                #[inline]
-                fn insert(&mut self, key: #ident, value: V) -> #option<V> {
-                    let [#(#names),*] = &mut self.data;
-
-                    match key {
-                        #(#ident::#variants => #mem::replace(#names, #option::Some(value)),)*
-                    }
-                }
-
-                #[inline]
-                fn contains_key(&self, value: #ident) -> bool {
-                    let [#(#names),*] = &self.data;
-
-                    match value {
-                        #(#ident::#variants => #option::is_some(#names),)*
-                    }
-                }
-
-                #[inline]
-                fn get(&self, value: #ident) -> #option<&V> {
-                    let [#(#names),*] = &self.data;
-
-                    match value {
-                        #(#ident::#variants => #option::as_ref(#names),)*
-                    }
-                }
-
-                #[inline]
-                fn get_mut(&mut self, value: #ident) -> #option<&mut V> {
-                    let [#(#names),*] = &mut self.data;
-
-                    match value {
-                        #(#ident::#variants => #option::as_mut(#names),)*
-                    }
-                }
-
-                #[inline]
-                fn remove(&mut self, value: #ident) -> #option<V> {
-                    let [#(#names),*] = &mut self.data;
-
-                    match value {
-                        #(#ident::#variants => #mem::take(#names),)*
-                    }
-                }
-
-                #[inline]
-                fn retain<F>(&mut self, mut func: F)
-                where
-                    F: FnMut(#ident, &mut V) -> bool
-                {
-                    let [#(#names),*] = &mut self.data;
-
-                    #(if let #option::Some(val) = #option::as_mut(#names) {
-                        if !func(#ident::#variants, val) {
-                            *#names = None;
-                        }
-                    })*
-                }
-
-                #[inline]
-                fn clear(&mut self) {
-                    self.data = [#(#field_inits),*];
-                }
-
-                #[inline]
-                fn iter(&self) -> Self::Iter<'_> {
-                    let [#(#names),*] = &self.data;
-                    #iterator_t::flat_map(#into_iterator_t::into_iter([#((#ident::#variants, #names)),*]), |(k, v)| #option::Some((k, #option::as_ref(v)?)))
-                }
-
-                #[inline]
-                fn keys(&self) -> Self::Keys<'_> {
-                    let [#(#names),*] = &self.data;
-                    #iterator_t::flatten(#into_iterator_t::into_iter([#(if #names.is_some() { Some(#ident::#variants) } else { None }),*]))
-                }
-
-                #[inline]
-                fn values(&self) -> Self::Values<'_> {
-                    #iterator_t::flatten(#into_iterator_t::into_iter(&self.data))
-                }
-
-                #[inline]
-                fn iter_mut(&mut self) -> Self::IterMut<'_> {
-                    let [#(#names),*] = &mut self.data;
-                    #iterator_t::flat_map(#into_iterator_t::into_iter([#((#ident::#variants, #names)),*]), |(k, v)| #option::Some((k, #option::as_mut(v)?)))
-                }
-
-                #[inline]
-                fn values_mut(&mut self) -> Self::ValuesMut<'_> {
-                    #iterator_t::flatten(#into_iterator_t::into_iter(&mut self.data))
-                }
-
-                #[inline]
-                fn into_iter(self) -> Self::IntoIter {
-                    let [#(#names),*] = self.data;
-                    #iterator_t::flat_map(#into_iterator_t::into_iter([#((#ident::#variants, #names)),*]), |(k, v)| #option::Some((k, v?)))
-                }
-
-                #[inline]
-                fn entry(&mut self, key: #ident) -> #entry_enum<'_, Self, #ident, V> {
-                    let [#(#names),*] = &mut self.data;
-
-                    match key {
-                        #(#ident::#variants => option_to_entry(#names, key),)*
-                    }
-                }
-            }
+            #storage_impl
+            #set_storage_impl
 
             #[automatically_derived]
             impl #key_t for #ident {
-                type Storage<V> = Storage<V>;
+                type Storage<V> = #storage<V>;
+                type SetStorage = SetStorage;
             }
 
             #entry_impl

--- a/fixed-map-derive/src/unit_variants.rs
+++ b/fixed-map-derive/src/unit_variants.rs
@@ -38,7 +38,7 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
     let partial_ord_t = cx.toks.partial_ord_t();
     let slice_iter = cx.toks.slice_iter();
     let slice_iter_mut = cx.toks.slice_iter_mut();
-    let storage_t = cx.toks.storage_t();
+    let map_storage_t = cx.toks.map_storage_t();
     let set_storage_t = cx.toks.set_storage_t();
     let vacant_entry_t = cx.toks.vacant_entry_t();
 
@@ -187,7 +187,7 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
         }
 
         #[automatically_derived]
-        impl<V> #storage_t<#ident, V> for #storage<V> {
+        impl<V> #map_storage_t<#ident, V> for #storage<V> {
             type Iter<#lt> = #iterator_flat_map<
                 #array_into_iter<(#ident, &#lt #option<V>), #count>,
                 #option<(#ident, &#lt V)>,
@@ -449,7 +449,7 @@ pub(crate) fn implement(cx: &Ctxt<'_>, en: &DataEnum) -> Result<TokenStream, ()>
 
             #[automatically_derived]
             impl #key_t for #ident {
-                type Storage<V> = #storage<V>;
+                type MapStorage<V> = #storage<V>;
                 type SetStorage = SetStorage;
             }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,6 +3,9 @@
 #[cfg(feature = "map")]
 use crate::map::storage::MapStorage;
 use crate::map::storage::{BooleanStorage, OptionStorage, SingletonStorage, Storage};
+#[cfg(feature = "map")]
+use crate::set::storage::HashbrownSetStorage;
+use crate::set::storage::{BooleanSetStorage, OptionSetStorage, SetStorage, SingletonSetStorage};
 
 /// The trait for a key that can be used to store values in a
 /// [`Map`][crate::Set] or [`Set`][crate::Set].
@@ -120,12 +123,18 @@ use crate::map::storage::{BooleanStorage, OptionStorage, SingletonStorage, Stora
 /// [`Map`]: crate::Map
 /// [`Set`]: crate::Set
 pub trait Key: Copy {
-    /// The `Storage` implementation to use for the key implementing this trait.
+    /// The [`Map`] `Storage` implementation to use for the key implementing
+    /// this trait.
     type Storage<V>: Storage<Self, V>;
+
+    /// The [`Set`] `Storage` implementation to use for the key implementing
+    /// this trait.
+    type SetStorage: SetStorage<Self>;
 }
 
 impl Key for bool {
     type Storage<V> = BooleanStorage<V>;
+    type SetStorage = BooleanSetStorage;
 }
 
 impl<K> Key for Option<K>
@@ -133,6 +142,7 @@ where
     K: Key,
 {
     type Storage<V> = OptionStorage<K, V>;
+    type SetStorage = OptionSetStorage<K>;
 }
 
 macro_rules! map_key {
@@ -140,6 +150,7 @@ macro_rules! map_key {
         #[cfg(feature = "map")]
         impl Key for $ty {
             type Storage<V> = MapStorage<$ty, V>;
+            type SetStorage = HashbrownSetStorage<$ty>;
         }
     };
 }
@@ -148,6 +159,7 @@ macro_rules! singleton_key {
     ($ty:ty) => {
         impl Key for $ty {
             type Storage<V> = SingletonStorage<V>;
+            type SetStorage = SingletonSetStorage;
         }
     };
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,9 +1,9 @@
 //! Module for the trait to define a `Key`.
 
-#[cfg(feature = "map")]
-use crate::map::storage::MapStorage;
-use crate::map::storage::{BooleanStorage, OptionStorage, SingletonStorage, Storage};
-#[cfg(feature = "map")]
+#[cfg(feature = "hashbrown")]
+use crate::map::storage::HashbrownMapStorage;
+use crate::map::storage::{BooleanMapStorage, MapStorage, OptionMapStorage, SingletonMapStorage};
+#[cfg(feature = "hashbrown")]
 use crate::set::storage::HashbrownSetStorage;
 use crate::set::storage::{BooleanSetStorage, OptionSetStorage, SetStorage, SingletonSetStorage};
 
@@ -50,7 +50,7 @@ use crate::set::storage::{BooleanSetStorage, OptionSetStorage, SetStorage, Singl
 ///
 /// #[derive(Clone, Copy, Key)]
 /// enum MyKey {
-///     # #[cfg(feature = "map")]
+///     # #[cfg(feature = "hashbrown")]
 ///     First(u32),
 ///     Second,
 /// }
@@ -123,17 +123,17 @@ use crate::set::storage::{BooleanSetStorage, OptionSetStorage, SetStorage, Singl
 /// [`Map`]: crate::Map
 /// [`Set`]: crate::Set
 pub trait Key: Copy {
-    /// The [`Map`] `Storage` implementation to use for the key implementing
+    /// The [`Map`] storage implementation to use for the key implementing
     /// this trait.
-    type Storage<V>: Storage<Self, V>;
+    type MapStorage<V>: MapStorage<Self, V>;
 
-    /// The [`Set`] `Storage` implementation to use for the key implementing
+    /// The [`Set`] storage implementation to use for the key implementing
     /// this trait.
     type SetStorage: SetStorage<Self>;
 }
 
 impl Key for bool {
-    type Storage<V> = BooleanStorage<V>;
+    type MapStorage<V> = BooleanMapStorage<V>;
     type SetStorage = BooleanSetStorage;
 }
 
@@ -141,15 +141,15 @@ impl<K> Key for Option<K>
 where
     K: Key,
 {
-    type Storage<V> = OptionStorage<K, V>;
+    type MapStorage<V> = OptionMapStorage<K, V>;
     type SetStorage = OptionSetStorage<K>;
 }
 
 macro_rules! map_key {
     ($ty:ty) => {
-        #[cfg(feature = "map")]
+        #[cfg(feature = "hashbrown")]
         impl Key for $ty {
-            type Storage<V> = MapStorage<$ty, V>;
+            type MapStorage<V> = HashbrownMapStorage<$ty, V>;
             type SetStorage = HashbrownSetStorage<$ty>;
         }
     };
@@ -158,7 +158,7 @@ macro_rules! map_key {
 macro_rules! singleton_key {
     ($ty:ty) => {
         impl Key for $ty {
-            type Storage<V> = SingletonStorage<V>;
+            type MapStorage<V> = SingletonMapStorage<V>;
             type SetStorage = SingletonSetStorage;
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,11 @@
 //!
 //! The following features are available:
 //!
-//! * `std` - Disabling this feature causes this crate to be no-std.
-//!   This means that dynamic types cannot be used in keys, like ones enabled by
-//!   the `map` feature (default).
-//! * `map` - Causes [`Storage`] to be implemented by dynamic types such as
-//!   `&'static str` or `u32`. These are backed by a `hashbrown` (default).
+//! * `std` - Disabling this feature causes this crate to be no-std. This means
+//!   that dynamic types cannot be used in keys, like ones enabled by the `map`
+//!   feature (default).
+//! * `hashbrown` - Causes [`Storage`] to be implemented by dynamic types such
+//!   as `&'static str` or `u32`. These are backed by a `hashbrown` (default).
 //! * `entry` - Enables an [`entry`] API similar to that found on [`HashMap`].
 //! * `serde` - Causes [`Map`] and [`Set`] to implement [`Serialize`] and
 //!   [`Deserialize`] if it's implemented by the key and value.

--- a/src/macro_support.rs
+++ b/src/macro_support.rs
@@ -4,6 +4,8 @@
 //! other purposes is not supported, and this API will not abide by semver
 //! stability guarantees.
 
+#![allow(clippy::missing_inline_in_public_items)]
+
 use core::cmp::Ordering;
 
 #[inline]
@@ -16,7 +18,6 @@ fn flatten<T>(value: (usize, &Option<T>)) -> Option<(usize, &T)> {
 
 /// `partial_cmp` implementation over iterators which ensures that storage
 /// ordering between `None` and `Some` is handled in a reasonable manner.
-#[allow(clippy::missing_inline_in_public_items)]
 pub fn __storage_iterator_partial_cmp<'a, A, B, T: 'a>(a: A, b: B) -> Option<Ordering>
 where
     A: IntoIterator<Item = &'a Option<T>>,
@@ -30,7 +31,6 @@ where
 
 /// `cmp` implementation over iterators which ensures that storage ordering
 /// between `None` and `Some` is handled in a reasonable manner.
-#[allow(clippy::missing_inline_in_public_items)]
 pub fn __storage_iterator_cmp<'a, A, B, T: 'a>(a: A, b: B) -> Ordering
 where
     A: IntoIterator<Item = &'a Option<T>>,
@@ -39,5 +39,34 @@ where
 {
     let a = a.into_iter().enumerate().filter_map(flatten);
     let b = b.into_iter().enumerate().filter_map(flatten);
+    a.cmp(b)
+}
+
+#[inline]
+fn filter_bool(&(_, value): &(usize, &bool)) -> bool {
+    *value
+}
+
+/// `partial_cmp` implementation over iterators which ensures that storage
+/// ordering between `false` and `true` is handled in a reasonable manner.
+pub fn __storage_iterator_partial_cmp_bool<'a, A, B>(a: A, b: B) -> Option<Ordering>
+where
+    A: IntoIterator<Item = &'a bool>,
+    B: IntoIterator<Item = &'a bool>,
+{
+    let a = a.into_iter().enumerate().filter(filter_bool);
+    let b = b.into_iter().enumerate().filter(filter_bool);
+    a.partial_cmp(b)
+}
+
+/// `cmp` implementation over iterators which ensures that storage ordering
+/// between `false` and `true` is handled in a reasonable manner.
+pub fn __storage_iterator_cmp_bool<'a, A, B>(a: A, b: B) -> Ordering
+where
+    A: IntoIterator<Item = &'a bool>,
+    B: IntoIterator<Item = &'a bool>,
+{
+    let a = a.into_iter().enumerate().filter(filter_bool);
+    let b = b.into_iter().enumerate().filter(filter_bool);
     a.cmp(b)
 }

--- a/src/map/entry.rs
+++ b/src/map/entry.rs
@@ -1,11 +1,11 @@
-use crate::map::{OccupiedEntry, Storage, VacantEntry};
+use crate::map::{MapStorage, OccupiedEntry, VacantEntry};
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
 ///
 /// This enum is constructed from the [`entry`][crate::Map::entry] method on [`Map`][crate::Map].
 pub enum Entry<'a, S: 'a, K, V>
 where
-    S: Storage<K, V>,
+    S: MapStorage<K, V>,
 {
     /// An occupied entry.
     Occupied(S::Occupied<'a>),
@@ -15,7 +15,7 @@ where
 
 impl<'a, S: 'a, K, V> Entry<'a, S, K, V>
 where
-    S: Storage<K, V>,
+    S: MapStorage<K, V>,
 {
     /// Ensures a value is in the entry by inserting the default if empty,
     /// and returns a mutable reference to the value in the entry.

--- a/src/map/storage.rs
+++ b/src/map/storage.rs
@@ -1,18 +1,18 @@
 //! Module that defines the [`Storage`] trait.
 
 mod boolean;
-pub(crate) use self::boolean::BooleanStorage;
+pub(crate) use self::boolean::BooleanMapStorage;
 
-#[cfg(feature = "map")]
-mod map;
-#[cfg(feature = "map")]
-pub(crate) use self::map::MapStorage;
+#[cfg(feature = "hashbrown")]
+mod hashbrown;
+#[cfg(feature = "hashbrown")]
+pub(crate) use self::hashbrown::HashbrownMapStorage;
 
 mod option;
-pub(crate) use self::option::OptionStorage;
+pub(crate) use self::option::OptionMapStorage;
 
 mod singleton;
-pub(crate) use self::singleton::SingletonStorage;
+pub(crate) use self::singleton::SingletonMapStorage;
 
 use crate::map::Entry;
 
@@ -22,7 +22,7 @@ use crate::map::Entry;
 ///
 /// - `K` is the key being stored.
 /// - `V` is the value being stored.
-pub trait Storage<K, V>: Sized {
+pub trait MapStorage<K, V>: Sized {
     /// Immutable iterator over storage.
     type Iter<'this>: Iterator<Item = (K, &'this V)>
     where

--- a/src/map/storage.rs
+++ b/src/map/storage.rs
@@ -1,4 +1,4 @@
-//! Module for the trait to define [`Storage`].
+//! Module that defines the [`Storage`] trait.
 
 mod boolean;
 pub(crate) use self::boolean::BooleanStorage;

--- a/src/map/storage/boolean.rs
+++ b/src/map/storage/boolean.rs
@@ -26,7 +26,7 @@ type IntoIter<V> = iter::Chain<
     iter::Map<option::IntoIter<V>, fn(V) -> (bool, V)>,
 >;
 
-/// Storage for [`bool`] types.
+/// [`Storage`] for [`bool`] types.
 ///
 /// # Examples
 ///

--- a/src/map/storage/boolean.rs
+++ b/src/map/storage/boolean.rs
@@ -5,7 +5,7 @@ use core::iter;
 use core::mem;
 use core::option;
 
-use crate::map::{Entry, OccupiedEntry, Storage, VacantEntry};
+use crate::map::{Entry, MapStorage, OccupiedEntry, VacantEntry};
 use crate::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 
 const TRUE_BIT: u8 = 0b10;
@@ -26,7 +26,7 @@ type IntoIter<V> = iter::Chain<
     iter::Map<option::IntoIter<V>, fn(V) -> (bool, V)>,
 >;
 
-/// [`Storage`] for [`bool`] types.
+/// [`MapStorage`] for [`bool`] types.
 ///
 /// # Examples
 ///
@@ -71,12 +71,12 @@ type IntoIter<V> = iter::Chain<
 /// ```
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct BooleanStorage<V> {
+pub struct BooleanMapStorage<V> {
     t: Option<V>,
     f: Option<V>,
 }
 
-/// See [`BooleanStorage::keys`].
+/// See [`BooleanMapStorage::keys`].
 pub struct Keys {
     bits: u8,
 }
@@ -191,7 +191,7 @@ impl<'a, V> OccupiedEntry<'a, bool, V> for Occupied<'a, V> {
     }
 }
 
-impl<V> Storage<bool, V> for BooleanStorage<V> {
+impl<V> MapStorage<bool, V> for BooleanMapStorage<V> {
     type Iter<'this> = Iter<'this, V> where V: 'this;
     type Keys<'this> = Keys where V: 'this;
     type Values<'this> = Values<'this, V> where V: 'this;

--- a/src/map/storage/hashbrown.rs
+++ b/src/map/storage/hashbrown.rs
@@ -1,14 +1,14 @@
 use core::hash::Hash;
 use core::iter;
 
-use crate::map::{Entry, OccupiedEntry, Storage, VacantEntry};
+use crate::map::{Entry, MapStorage, OccupiedEntry, VacantEntry};
 
 type S = ::hashbrown::hash_map::DefaultHashBuilder;
 type Occupied<'a, K, V> = ::hashbrown::hash_map::OccupiedEntry<'a, K, V, S>;
 type Vacant<'a, K, V> = ::hashbrown::hash_map::VacantEntry<'a, K, V, S>;
 type HashMapEntry<'a, K, V> = ::hashbrown::hash_map::Entry<'a, K, V, S>;
 
-/// [`Storage`] for dynamic types, using [`hashbrown::HashMap`].
+/// [`MapStorage`] for dynamic types, using [`hashbrown::HashMap`].
 ///
 /// This allows for dynamic types such as `&'static str` or `u32` to be used as
 /// a [`Key`][crate::Key].
@@ -31,24 +31,24 @@ type HashMapEntry<'a, K, V> = ::hashbrown::hash_map::Entry<'a, K, V, S>;
 /// assert_eq!(map.get(Key::Second), None);
 /// ```
 #[repr(transparent)]
-pub struct MapStorage<K, V> {
+pub struct HashbrownMapStorage<K, V> {
     inner: ::hashbrown::HashMap<K, V>,
 }
 
-impl<K, V> Clone for MapStorage<K, V>
+impl<K, V> Clone for HashbrownMapStorage<K, V>
 where
     K: Clone,
     V: Clone,
 {
     #[inline]
     fn clone(&self) -> Self {
-        MapStorage {
+        Self {
             inner: self.inner.clone(),
         }
     }
 }
 
-impl<K, V> PartialEq for MapStorage<K, V>
+impl<K, V> PartialEq for HashbrownMapStorage<K, V>
 where
     K: Eq + Hash,
     V: PartialEq,
@@ -59,7 +59,7 @@ where
     }
 }
 
-impl<K, V> Eq for MapStorage<K, V>
+impl<K, V> Eq for HashbrownMapStorage<K, V>
 where
     K: Eq + Hash,
     V: Eq,
@@ -116,7 +116,7 @@ where
     }
 }
 
-impl<K, V> Storage<K, V> for MapStorage<K, V>
+impl<K, V> MapStorage<K, V> for HashbrownMapStorage<K, V>
 where
     K: Copy + Eq + Hash,
 {

--- a/src/map/storage/map.rs
+++ b/src/map/storage/map.rs
@@ -8,7 +8,7 @@ type Occupied<'a, K, V> = ::hashbrown::hash_map::OccupiedEntry<'a, K, V, S>;
 type Vacant<'a, K, V> = ::hashbrown::hash_map::VacantEntry<'a, K, V, S>;
 type HashMapEntry<'a, K, V> = ::hashbrown::hash_map::Entry<'a, K, V, S>;
 
-/// Storage for dynamic types, using [`hashbrown::HashMap`].
+/// [`Storage`] for dynamic types, using [`hashbrown::HashMap`].
 ///
 /// This allows for dynamic types such as `&'static str` or `u32` to be used as
 /// a [`Key`][crate::Key].

--- a/src/map/storage/option.rs
+++ b/src/map/storage/option.rs
@@ -33,7 +33,7 @@ type IntoIter<K, V> = iter::Chain<
     iter::Map<option::IntoIter<V>, fn(V) -> (Option<K>, V)>,
 >;
 
-/// Storage for [`Option`] types.
+/// [`Storage`] for [`Option`] types.
 ///
 /// # Examples
 ///

--- a/src/map/storage/singleton.rs
+++ b/src/map/storage/singleton.rs
@@ -1,16 +1,16 @@
 use core::mem;
 
-use crate::map::{Entry, Storage};
+use crate::map::{Entry, MapStorage};
 use crate::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 
-/// [`Storage`] type that can only inhabit a single value (like `()`).
+/// [`MapStorage`] type that can only inhabit a single value (like `()`).
 #[repr(transparent)]
 #[derive(Clone, Copy)]
-pub struct SingletonStorage<V> {
+pub struct SingletonMapStorage<V> {
     inner: Option<V>,
 }
 
-impl<V> PartialEq for SingletonStorage<V>
+impl<V> PartialEq for SingletonMapStorage<V>
 where
     V: PartialEq,
 {
@@ -20,9 +20,9 @@ where
     }
 }
 
-impl<V> Eq for SingletonStorage<V> where V: Eq {}
+impl<V> Eq for SingletonMapStorage<V> where V: Eq {}
 
-impl<K, V> Storage<K, V> for SingletonStorage<V>
+impl<K, V> MapStorage<K, V> for SingletonMapStorage<V>
 where
     K: Default,
 {

--- a/src/map/storage/singleton.rs
+++ b/src/map/storage/singleton.rs
@@ -3,7 +3,7 @@ use core::mem;
 use crate::map::{Entry, Storage};
 use crate::option_bucket::{NoneBucket, OptionBucket, SomeBucket};
 
-/// Storage types that can only inhabit a single value (like `()`).
+/// [`Storage`] type that can only inhabit a single value (like `()`).
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct SingletonStorage<V> {

--- a/src/set.rs
+++ b/src/set.rs
@@ -32,9 +32,9 @@ pub type IntoIter<T> = <<T as Key>::SetStorage as SetStorage<T>>::IntoIter;
 /// enum Key {
 ///     Simple,
 ///     Composite(Part),
-///     # #[cfg(feature = "map")]
+///     # #[cfg(feature = "hashbrown")]
 ///     String(&'static str),
-///     # #[cfg(feature = "map")]
+///     # #[cfg(feature = "hashbrown")]
 ///     Number(u32),
 ///     Singleton(()),
 ///     Option(Option<Part>),
@@ -45,9 +45,9 @@ pub type IntoIter<T> = <<T as Key>::SetStorage as SetStorage<T>>::IntoIter;
 ///
 /// set.insert(Key::Simple);
 /// set.insert(Key::Composite(Part::One));
-/// # #[cfg(feature = "map")]
+/// # #[cfg(feature = "hashbrown")]
 /// set.insert(Key::String("foo"));
-/// # #[cfg(feature = "map")]
+/// # #[cfg(feature = "hashbrown")]
 /// set.insert(Key::Number(1));
 /// set.insert(Key::Singleton(()));
 /// set.insert(Key::Option(None));
@@ -57,13 +57,13 @@ pub type IntoIter<T> = <<T as Key>::SetStorage as SetStorage<T>>::IntoIter;
 /// assert!(set.contains(Key::Simple));
 /// assert!(set.contains(Key::Composite(Part::One)));
 /// assert!(!set.contains(Key::Composite(Part::Two)));
-/// # #[cfg(feature = "map")]
+/// # #[cfg(feature = "hashbrown")]
 /// assert!(set.contains(Key::String("foo")));
-/// # #[cfg(feature = "map")]
+/// # #[cfg(feature = "hashbrown")]
 /// assert!(!set.contains(Key::String("bar")));
-/// # #[cfg(feature = "map")]
+/// # #[cfg(feature = "hashbrown")]
 /// assert!(set.contains(Key::Number(1)));
-/// # #[cfg(feature = "map")]
+/// # #[cfg(feature = "hashbrown")]
 /// assert!(!set.contains(Key::Number(2)));
 /// assert!(set.contains(Key::Singleton(())));
 /// assert!(set.contains(Key::Option(None)));

--- a/src/set/storage.rs
+++ b/src/set/storage.rs
@@ -6,9 +6,9 @@ pub use self::singleton::SingletonSetStorage;
 mod boolean;
 pub use self::boolean::BooleanSetStorage;
 
-#[cfg(feature = "map")]
+#[cfg(feature = "hashbrown")]
 mod hashbrown;
-#[cfg(feature = "map")]
+#[cfg(feature = "hashbrown")]
 pub use self::hashbrown::HashbrownSetStorage;
 
 mod option;

--- a/src/set/storage.rs
+++ b/src/set/storage.rs
@@ -1,0 +1,62 @@
+//! Module that defines the [`SetStorage`] trait.
+
+mod singleton;
+pub use self::singleton::SingletonSetStorage;
+
+mod boolean;
+pub use self::boolean::BooleanSetStorage;
+
+#[cfg(feature = "map")]
+mod hashbrown;
+#[cfg(feature = "map")]
+pub use self::hashbrown::HashbrownSetStorage;
+
+mod option;
+pub use self::option::OptionSetStorage;
+
+/// The trait defining how storage works for [`Set`][crate::Set].
+///
+/// # Type Arguments
+///
+/// - `T` is the key being stored.
+pub trait SetStorage<T>: Sized {
+    /// Immutable iterator over storage.
+    type Iter<'this>: Iterator<Item = T>
+    where
+        Self: 'this;
+
+    /// Owning iterator over the storage.
+    type IntoIter: Iterator<Item = T>;
+
+    /// Construct empty storage.
+    fn empty() -> Self;
+
+    /// Get the length of storage.
+    fn len(&self) -> usize;
+
+    /// Check if storage is empty.
+    fn is_empty(&self) -> bool;
+
+    /// This is the storage abstraction for [`Set::insert`][crate::Set::insert].
+    fn insert(&mut self, value: T) -> bool;
+
+    /// This is the storage abstraction for [`Set::contains`][crate::Set::contains].
+    fn contains(&self, value: T) -> bool;
+
+    /// This is the storage abstraction for [`Set::remove`][crate::Set::remove].
+    fn remove(&mut self, value: T) -> bool;
+
+    /// This is the storage abstraction for [`Set::retain`][crate::Set::retain].
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(T) -> bool;
+
+    /// This is the storage abstraction for [`Set::clear`][crate::Set::clear].
+    fn clear(&mut self);
+
+    /// This is the storage abstraction for [`Set::iter`][crate::Set::iter].
+    fn iter(&self) -> Self::Iter<'_>;
+
+    /// This is the storage abstraction for [`Set::into_iter`][crate::Set::into_iter].
+    fn into_iter(self) -> Self::IntoIter;
+}

--- a/src/set/storage/boolean.rs
+++ b/src/set/storage/boolean.rs
@@ -1,0 +1,198 @@
+// Iterators are confusing if they impl `Copy`.
+#![allow(missing_copy_implementations)]
+
+use core::mem;
+
+use crate::set::SetStorage;
+
+const TRUE_BIT: u8 = 0b10;
+const FALSE_BIT: u8 = 0b01;
+
+/// [`SetStorage`] for [`bool`] types.
+///
+/// # Examples
+///
+/// ```
+/// use fixed_map::{Key, Set};
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Key)]
+/// enum Key {
+///     First(bool),
+///     Second,
+/// }
+///
+/// let mut a = Set::new();
+/// a.insert(Key::First(false));
+///
+/// assert!(!a.contains(Key::First(true)));
+/// assert!(a.contains(Key::First(false)));
+/// assert!(!a.contains(Key::Second));
+///
+/// assert!(a.iter().eq([Key::First(false)]));
+/// ```
+///
+/// Iterator over boolean set:
+///
+/// ```
+/// use fixed_map::{Key, Set};
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Key)]
+/// enum Key {
+///     Bool(bool),
+///     Other,
+/// }
+///
+/// let mut a = Set::new();
+/// a.insert(Key::Bool(true));
+/// a.insert(Key::Bool(false));
+///
+/// assert!(a.iter().eq([Key::Bool(true), Key::Bool(false)]));
+/// assert_eq!(a.iter().rev().collect::<Vec<_>>(), vec![Key::Bool(false), Key::Bool(true)]);
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BooleanSetStorage {
+    bits: u8,
+}
+
+/// See [`BooleanSetStorage::iter`].
+pub struct Iter {
+    bits: u8,
+}
+
+impl Clone for Iter {
+    #[inline]
+    fn clone(&self) -> Iter {
+        Iter { bits: self.bits }
+    }
+}
+
+impl Iterator for Iter {
+    type Item = bool;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bits & TRUE_BIT != 0 {
+            self.bits &= !TRUE_BIT;
+            return Some(true);
+        }
+
+        if self.bits & FALSE_BIT != 0 {
+            self.bits &= !FALSE_BIT;
+            return Some(false);
+        }
+
+        None
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.bits.count_ones() as usize;
+        (len, Some(len))
+    }
+}
+
+impl DoubleEndedIterator for Iter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.bits & FALSE_BIT != 0 {
+            self.bits &= !FALSE_BIT;
+            return Some(false);
+        }
+
+        if self.bits & TRUE_BIT != 0 {
+            self.bits &= !TRUE_BIT;
+            return Some(true);
+        }
+
+        None
+    }
+}
+
+impl ExactSizeIterator for Iter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.bits.count_ones() as usize
+    }
+}
+
+impl SetStorage<bool> for BooleanSetStorage {
+    type Iter<'this> = Iter;
+    type IntoIter = Iter;
+
+    #[inline]
+    fn empty() -> Self {
+        Self { bits: 0 }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        usize::from(self.bits & TRUE_BIT != 0)
+            .saturating_add(usize::from(self.bits & FALSE_BIT != 0))
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.bits == 0
+    }
+
+    #[inline]
+    fn insert(&mut self, value: bool) -> bool {
+        let update = self.bits | to_bits(value);
+        test(mem::replace(&mut self.bits, update), value)
+    }
+
+    #[inline]
+    fn contains(&self, value: bool) -> bool {
+        test(self.bits, value)
+    }
+
+    #[inline]
+    fn remove(&mut self, value: bool) -> bool {
+        let value = to_bits(value);
+        let update = self.bits & !value;
+        mem::replace(&mut self.bits, update) != 0
+    }
+
+    #[inline]
+    fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(bool) -> bool,
+    {
+        if test(self.bits, true) && !f(true) {
+            self.bits &= !TRUE_BIT;
+        }
+
+        if test(self.bits, false) && !f(false) {
+            self.bits &= !FALSE_BIT;
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.bits = 0;
+    }
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        Iter { bits: self.bits }
+    }
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        Iter { bits: self.bits }
+    }
+}
+
+#[inline]
+const fn test(bits: u8, value: bool) -> bool {
+    bits & to_bits(value) != 0
+}
+
+#[inline]
+const fn to_bits(value: bool) -> u8 {
+    if value {
+        TRUE_BIT
+    } else {
+        FALSE_BIT
+    }
+}

--- a/src/set/storage/hashbrown.rs
+++ b/src/set/storage/hashbrown.rs
@@ -1,0 +1,118 @@
+use core::hash::Hash;
+use core::iter;
+
+use crate::set::SetStorage;
+
+/// [`SetStorage`] for dynamically stored types, using [`hashbrown::HashSet`].
+///
+/// This allows for dynamic types such as `&'static str` or `u32` to be used as
+/// a [`Key`][crate::Key].
+///
+/// # Examples
+///
+/// ```
+/// use fixed_map::{Key, Set};
+///
+/// #[derive(Clone, Copy, Key)]
+/// enum Key {
+///     First(u32),
+///     Second,
+/// }
+///
+/// let mut map = Set::new();
+/// map.insert(Key::First(1));
+/// assert_eq!(map.contains(Key::First(1)), true);
+/// assert_eq!(map.contains(Key::First(2)), false);
+/// assert_eq!(map.contains(Key::Second), false);
+/// ```
+#[repr(transparent)]
+pub struct HashbrownSetStorage<T> {
+    inner: ::hashbrown::HashSet<T>,
+}
+
+impl<T> Clone for HashbrownSetStorage<T>
+where
+    T: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        HashbrownSetStorage {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> PartialEq for HashbrownSetStorage<T>
+where
+    T: Eq + Hash,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl<T> Eq for HashbrownSetStorage<T> where T: Eq + Hash {}
+
+impl<T> SetStorage<T> for HashbrownSetStorage<T>
+where
+    T: Copy + Eq + Hash,
+{
+    type Iter<'this> = iter::Copied<::hashbrown::hash_set::Iter<'this, T>> where T: 'this;
+    type IntoIter = ::hashbrown::hash_set::IntoIter<T>;
+
+    #[inline]
+    fn empty() -> Self {
+        Self {
+            inner: ::hashbrown::HashSet::new(),
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    fn insert(&mut self, value: T) -> bool {
+        self.inner.insert(value)
+    }
+
+    #[inline]
+    fn contains(&self, value: T) -> bool {
+        self.inner.contains(&value)
+    }
+
+    #[inline]
+    fn remove(&mut self, value: T) -> bool {
+        self.inner.remove(&value)
+    }
+
+    #[inline]
+    fn retain<F>(&mut self, mut func: F)
+    where
+        F: FnMut(T) -> bool,
+    {
+        self.inner.retain(|&value| func(value));
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        self.inner.iter().copied()
+    }
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}

--- a/src/set/storage/option.rs
+++ b/src/set/storage/option.rs
@@ -1,0 +1,180 @@
+use core::iter;
+use core::mem;
+use core::option;
+
+use crate::key::Key;
+use crate::set::SetStorage;
+
+type Iter<'a, T> = iter::Chain<
+    iter::Map<<<T as Key>::SetStorage as SetStorage<T>>::Iter<'a>, fn(T) -> Option<T>>,
+    option::IntoIter<Option<T>>,
+>;
+type IntoIter<T> = iter::Chain<
+    iter::Map<<<T as Key>::SetStorage as SetStorage<T>>::IntoIter, fn(T) -> Option<T>>,
+    option::IntoIter<Option<T>>,
+>;
+
+/// [`SetStorage`] for [`Option`] types.
+///
+/// # Examples
+///
+/// ```
+/// use fixed_map::{Key, Map};
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Key)]
+/// enum Part {
+///     A,
+///     B,
+/// }
+///
+/// #[derive(Debug, Clone, Copy, PartialEq, Key)]
+/// enum Key {
+///     First(Option<Part>),
+///     Second,
+/// }
+///
+/// let mut a = Map::new();
+/// a.insert(Key::First(None), 1);
+/// a.insert(Key::First(Some(Part::A)), 2);
+///
+/// assert_eq!(a.get(Key::First(Some(Part::A))), Some(&2));
+/// assert_eq!(a.get(Key::First(Some(Part::B))), None);
+/// assert_eq!(a.get(Key::First(None)), Some(&1));
+/// assert_eq!(a.get(Key::Second), None);
+///
+/// assert!(a.iter().eq([(Key::First(Some(Part::A)), &2), (Key::First(None), &1)]));
+/// assert!(a.values().copied().eq([2, 1]));
+/// assert!(a.keys().eq([Key::First(Some(Part::A)), Key::First(None)]));
+/// ```
+pub struct OptionSetStorage<T>
+where
+    T: Key,
+{
+    some: T::SetStorage,
+    none: bool,
+}
+
+impl<T> Clone for OptionSetStorage<T>
+where
+    T: Key,
+    T::SetStorage: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            some: self.some.clone(),
+            none: self.none,
+        }
+    }
+}
+
+impl<T> Copy for OptionSetStorage<T>
+where
+    T: Key,
+    T::SetStorage: Copy,
+{
+}
+
+impl<T> PartialEq for OptionSetStorage<T>
+where
+    T: Key,
+    T::SetStorage: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.none == other.none && self.some == other.some
+    }
+}
+
+impl<T> Eq for OptionSetStorage<T>
+where
+    T: Key,
+    T::SetStorage: Eq,
+{
+}
+
+impl<T> SetStorage<Option<T>> for OptionSetStorage<T>
+where
+    T: Key,
+{
+    type Iter<'this> = Iter<'this, T> where T: 'this;
+    type IntoIter = IntoIter<T>;
+
+    #[inline]
+    fn empty() -> Self {
+        Self {
+            some: T::SetStorage::empty(),
+            none: false,
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.some.len() + usize::from(self.none)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.some.is_empty() && self.none
+    }
+
+    #[inline]
+    fn insert(&mut self, value: Option<T>) -> bool {
+        match value {
+            Some(value) => self.some.insert(value),
+            None => mem::replace(&mut self.none, true),
+        }
+    }
+
+    #[inline]
+    fn contains(&self, value: Option<T>) -> bool {
+        match value {
+            Some(key) => self.some.contains(key),
+            None => self.none,
+        }
+    }
+
+    #[inline]
+    fn remove(&mut self, key: Option<T>) -> bool {
+        match key {
+            Some(key) => self.some.remove(key),
+            None => mem::replace(&mut self.none, false),
+        }
+    }
+
+    #[inline]
+    fn retain<F>(&mut self, mut func: F)
+    where
+        F: FnMut(Option<T>) -> bool,
+    {
+        self.some.retain(|value| func(Some(value)));
+
+        if self.none {
+            self.none = func(None);
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.some.clear();
+        self.none = false;
+    }
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        let map: fn(_) -> _ = Some;
+        self.some
+            .iter()
+            .map(map)
+            .chain(self.none.then_some(None::<T>))
+    }
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        let map: fn(_) -> _ = Some;
+        self.some
+            .into_iter()
+            .map(map)
+            .chain(self.none.then_some(None::<T>))
+    }
+}

--- a/src/set/storage/singleton.rs
+++ b/src/set/storage/singleton.rs
@@ -1,0 +1,71 @@
+use core::mem;
+
+use crate::set::SetStorage;
+
+/// [`SetStorage`]  types that can only inhabit a single value (like `()`).
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SingletonSetStorage {
+    is_set: bool,
+}
+
+impl<T> SetStorage<T> for SingletonSetStorage
+where
+    T: Default,
+{
+    type Iter<'this> = ::core::option::IntoIter<T>;
+    type IntoIter = ::core::option::IntoIter<T>;
+
+    #[inline]
+    fn empty() -> Self {
+        Self { is_set: false }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        usize::from(self.is_set)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        !self.is_set
+    }
+
+    #[inline]
+    fn insert(&mut self, _: T) -> bool {
+        !mem::replace(&mut self.is_set, true)
+    }
+
+    #[inline]
+    fn contains(&self, _: T) -> bool {
+        self.is_set
+    }
+
+    #[inline]
+    fn remove(&mut self, _: T) -> bool {
+        mem::replace(&mut self.is_set, false)
+    }
+
+    #[inline]
+    fn retain<F>(&mut self, mut func: F)
+    where
+        F: FnMut(T) -> bool,
+    {
+        self.is_set = func(T::default());
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.is_set = false;
+    }
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        self.is_set.then_some(T::default()).into_iter()
+    }
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.is_set.then_some(T::default()).into_iter()
+    }
+}

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -64,7 +64,7 @@ fn composite() {
     assert_eq!(map.get(Key::Second), Some(&vec![2; 4]));
 }
 
-#[cfg(feature = "map")]
+#[cfg(feature = "hashbrown")]
 #[test]
 fn compound() {
     #[derive(Clone, Copy, Key)]

--- a/tests/map_feature.rs
+++ b/tests/map_feature.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "map")]
+#![cfg(feature = "hashbrown")]
 
 use fixed_map::{Key, Map};
 


### PR DESCRIPTION
First step towards generating optimized storage for sets (which will eventually allow for #36).

~~It's currently pretty broken, so a compat shim is used by default unless `fixed_map_derived_set_storage` is enabled.~~