### PR TITLE
Implement bitset storage for sets

### DIFF
--- a/fixed-map-derive/src/attrs.rs
+++ b/fixed-map-derive/src/attrs.rs
@@ -1,0 +1,40 @@
+use syn::spanned::Spanned;
+use syn::{Meta, NestedMeta};
+
+use crate::context::{Ctxt, Opts};
+use crate::symbol;
+
+/// Parse attributes.
+pub(crate) fn parse(cx: &Ctxt<'_>) -> Result<Opts, ()> {
+    let mut opts = Opts::default();
+
+    for attr in &cx.ast.attrs {
+        if attr.path != symbol::KEY {
+            continue;
+        }
+
+        let meta = cx.fallible(|| attr.parse_meta())?;
+
+        let nested = match meta {
+            Meta::List(meta) => meta.nested.into_iter(),
+            other => {
+                cx.error(other.span(), "unsupported attribute");
+                return Err(());
+            }
+        };
+
+        for meta in nested {
+            match meta {
+                NestedMeta::Meta(Meta::Path(p)) if p == symbol::BITSET => {
+                    opts.bitset = Some(p.span());
+                }
+                other => {
+                    cx.error(other.span(), "unsupported attribute");
+                    return Err(());
+                }
+            }
+        }
+    }
+
+    Ok(opts)
+}

--- a/fixed-map-derive/src/context.rs
+++ b/fixed-map-derive/src/context.rs
@@ -113,6 +113,13 @@ fn suffixed<const N: usize>(prefix: &Path, parts: [&'static str; N]) -> Path {
     path
 }
 
+/// Options for derive.
+#[derive(Default)]
+pub(crate) struct Opts {
+    /// Implements sets as bitsets when possible.
+    pub(crate) bitset: Option<Span>,
+}
+
 pub(crate) struct Ctxt<'a> {
     /// Errors collected in the context.
     errors: RefCell<Vec<syn::Error>>,

--- a/fixed-map-derive/src/lib.rs
+++ b/fixed-map-derive/src/lib.rs
@@ -64,7 +64,9 @@ use syn::spanned::Spanned;
 use syn::{Data, DataEnum, DeriveInput, Fields};
 
 mod any_variants;
+mod attrs;
 mod context;
+mod symbol;
 mod unit_variants;
 
 /// Derive to implement the `Key` trait.
@@ -161,9 +163,11 @@ pub fn storage_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 
 /// Derive to implement the `Key` trait.
 fn impl_storage(cx: &context::Ctxt<'_>) -> Result<TokenStream, ()> {
+    let opts = attrs::parse(cx)?;
+
     if let Data::Enum(en) = &cx.ast.data {
         if is_all_unit_variants(en) {
-            unit_variants::implement(cx, en)
+            unit_variants::implement(cx, &opts, en)
         } else {
             any_variants::implement(cx, en)
         }

--- a/fixed-map-derive/src/symbol.rs
+++ b/fixed-map-derive/src/symbol.rs
@@ -1,0 +1,47 @@
+use core::fmt;
+use core::ops::Deref;
+use syn::{Ident, Path};
+
+#[derive(Copy, Clone)]
+pub struct Symbol(&'static str);
+
+pub(crate) const KEY: Symbol = Symbol("key");
+pub(crate) const BITSET: Symbol = Symbol("bitset");
+
+impl PartialEq<Symbol> for Ident {
+    fn eq(&self, word: &Symbol) -> bool {
+        self == word.0
+    }
+}
+
+impl PartialEq<Symbol> for &Ident {
+    fn eq(&self, word: &Symbol) -> bool {
+        *self == word.0
+    }
+}
+
+impl PartialEq<Symbol> for Path {
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
+}
+
+impl PartialEq<Symbol> for &Path {
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+impl Deref for Symbol {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}


### PR DESCRIPTION
This introduces an experimental attribute `#[key(bitset)]` which when applies to the `Key` derive will cause the underlying storage to use an integer for sets.

Missing a working ordering implementation. I'm sure there's some smart way to fix it (other than constructing a slow iterator), but I'm a bit burned out right now to figure it out!

Relates to #36